### PR TITLE
Upgrade gir.core from 0.7.0 to 0.8.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,12 @@
         "**/.git": true
     },
     "files.watcherExclude": {
+        ".git/objects/**": true,
+        ".git/subtree-cache/**": true,
+        ".hg/store/**": true,
+        "*/.git/objects/**": true,
+        "*/.git/subtree-cache/**": true,
+        "*/.hg/store/**": true,
         "**/.git/objects/**": true,
         "**/.git/subtree-cache/**": true,
         "**/.hg/store/**": true,

--- a/Stocks.csproj
+++ b/Stocks.csproj
@@ -14,12 +14,13 @@
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>false</PublishTrimmed>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks> 
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="GirCore.Adw-1" Version="0.7.0" />
-    <PackageReference Include="GirCore.Gtk-4.0" Version="0.7.0" />
-    <PackageReference Include="GirCore.GObject-2.0.Integration" Version="0.7.0" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <PackageReference Include="GirCore.Adw-1" Version="0.8.0" />
+    <PackageReference Include="GirCore.Gtk-4.0" Version="0.8.0" />
+    <PackageReference Include="GirCore.GObject-2.0" Version="0.8.0" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <PackageReference Include="NGettext" Version="0.6.7" />
   </ItemGroup>
   

--- a/Stocks/Application.cs
+++ b/Stocks/Application.cs
@@ -3,6 +3,7 @@
 
 using Stocks.UI;
 using Stocks.Model;
+using static Stocks.Translations;
 
 public class Application
 {
@@ -28,7 +29,7 @@ public class Application
     private void OnActivate(Gio.Application application, EventArgs eventArgs)
     {
         Styles.Load();
-        mainWindow ??= new MainWindow((Adw.Application)application, model, settings);
+        mainWindow ??= MainWindow.NewWithModel((Adw.Application)application, model, settings);
         mainWindow.Present();
     }
 

--- a/Stocks/Model/TickerRange.cs
+++ b/Stocks/Model/TickerRange.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Lauri Taimila
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+using static Stocks.Translations;
+
 namespace Stocks.Model;
 
 public enum TickerRange

--- a/Stocks/Model/Watchlists/WatchlistMigrator.cs
+++ b/Stocks/Model/Watchlists/WatchlistMigrator.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Lauri Taimila
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+using static Stocks.Translations;
+
 namespace Stocks.Model;
 
 /// <summary>

--- a/Stocks/Model/Watchlists/WatchlistStorage.cs
+++ b/Stocks/Model/Watchlists/WatchlistStorage.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using System.Text.Json;
+using static Stocks.Translations;
 
 namespace Stocks.Model;
 

--- a/Stocks/Program.cs
+++ b/Stocks/Program.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 global using static Stocks.Constants;
-global using static Stocks.Translations;
 
 namespace Stocks;
 

--- a/Stocks/Ui/AddTicker/AddButton.cs
+++ b/Stocks/Ui/AddTicker/AddButton.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Stocks.Model;
+using static Stocks.Translations;
 
 namespace Stocks.UI;
 

--- a/Stocks/Ui/AddTicker/AddTickerPopover.cs
+++ b/Stocks/Ui/AddTicker/AddTickerPopover.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Stocks.Model;
+using static Stocks.Translations;
 
 namespace Stocks.UI;
 
@@ -181,7 +182,7 @@ class AddTickerView : Gtk.Box
             add.Valign = Gtk.Align.Center;
             add.TooltipText = canAdd ? _("Add to watchlist") : _("Already on watchlist");
 
-            var sidebarItem = new SidebarItem(g1, g2, g3, model.GetEmpheralTicker(result.Symbol));
+            var sidebarItem = SidebarItem.NewWithTicker(g1, g2, g3, model.GetEmpheralTicker(result.Symbol));
             sidebarItem.Sensitive = canAdd;
 
             // Hack to fix padding issue of the name label when in popover.

--- a/Stocks/Ui/Details/Dropdown.cs
+++ b/Stocks/Ui/Details/Dropdown.cs
@@ -35,7 +35,7 @@ public class KeyValueDropDown: Gtk.DropDown
         var listStore = Gio.ListStore.New(DropdownItem.GetGType());
         foreach (var item in items)
         {
-            listStore.Append(new DropdownItem(item.Key, item.Value));
+            listStore.Append(DropdownItem.NewWithKeyValue(item.Key, item.Value));
         }
 
         this.SetModel(listStore);
@@ -63,7 +63,7 @@ public class KeyValueDropDown: Gtk.DropDown
             store!.RemoveAll();
             foreach (var item in items)
             {
-                store.Append(new DropdownItem(item.Key, item.Value));
+                store.Append(DropdownItem.NewWithKeyValue(item.Key, item.Value));
             }
 
             // Restore the previous selection if it still exists, otherwise select first item
@@ -173,12 +173,17 @@ public class KeyValueDropDown: Gtk.DropDown
 [GObject.Subclass<GObject.Object>]
 public partial class DropdownItem
 {
-    public DropdownItem(string key, string value) : this()
+    string key;
+    string value;
+
+    public static DropdownItem NewWithKeyValue(string key, string value)
     {
-        Key = key;
-        Value = value;
+        var obj = NewWithProperties([]);
+        obj.key = key;
+        obj.value = value;
+        return obj;
     }
 
-    public string Key { get; }
-    public string Value { get; }
+    public string Key => key;
+    public string Value => value;
 }

--- a/Stocks/Ui/Details/TickerChartPopover.cs
+++ b/Stocks/Ui/Details/TickerChartPopover.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Stocks.Model;
+using static Stocks.Translations;
 
 namespace Stocks.UI;
 

--- a/Stocks/Ui/Details/TickerDetails.cs
+++ b/Stocks/Ui/Details/TickerDetails.cs
@@ -2,74 +2,80 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Stocks.Model;
+using static Stocks.Translations;
 
 namespace Stocks.UI;
 
-public class TickerDetails : Gtk.Box
+[GObject.Subclass<Gtk.Box>(qualifiedName: nameof(TickerDetails))]
+[Gtk.Template<Gtk.AssemblyResource>("TickerDetails.ui")]
+public partial class TickerDetails
 {
-    [Gtk.Connect] private readonly Gtk.Box cardContent;
+    [Gtk.Connect] private Gtk.Box cardContent;
 
     // Main containers to switch between details / no-details
-    [Gtk.Connect] private readonly Gtk.Box noDetails;
-    [Gtk.Connect] private readonly Adw.Clamp detailsCard;
-    [Gtk.Connect] private readonly Adw.Clamp detailsFooter;
+    [Gtk.Connect] private Gtk.Box noDetails;
+    [Gtk.Connect] private Adw.Clamp detailsCard;
+    [Gtk.Connect] private Adw.Clamp detailsFooter;
 
     // Header
-    [Gtk.Connect] private readonly Gtk.Grid narrowHeader;
-    [Gtk.Connect] private readonly Gtk.Grid wideHeader;
+    [Gtk.Connect] private Gtk.Grid narrowHeader;
+    [Gtk.Connect] private Gtk.Grid wideHeader;
 
-    [Gtk.Connect] private readonly Gtk.Label name;
-    [Gtk.Connect] private readonly Gtk.Label symbol;
-    [Gtk.Connect] private readonly Gtk.Box symbolDisplayBox;
-    [Gtk.Connect] private readonly Gtk.Box symbolEditBox;
-    [Gtk.Connect] private readonly Gtk.Entry aliasEntry;
-    [Gtk.Connect] private readonly Gtk.Button aliasSaveButton;
-    [Gtk.Connect] private readonly Gtk.Label currentValue;
-    [Gtk.Connect] private readonly Gtk.Label changePercentage;
-    [Gtk.Connect] private readonly Gtk.Label name2;
-    [Gtk.Connect] private readonly Gtk.Label currentValue2;
-    [Gtk.Connect] private readonly Gtk.Label changePercentage2;
+    [Gtk.Connect] private Gtk.Label name;
+    [Gtk.Connect] private Gtk.Label symbol;
+    [Gtk.Connect] private Gtk.Box symbolDisplayBox;
+    [Gtk.Connect] private Gtk.Box symbolEditBox;
+    [Gtk.Connect] private Gtk.Entry aliasEntry;
+    [Gtk.Connect] private Gtk.Button aliasSaveButton;
+    [Gtk.Connect] private Gtk.Label currentValue;
+    [Gtk.Connect] private Gtk.Label changePercentage;
+    [Gtk.Connect] private Gtk.Label name2;
+    [Gtk.Connect] private Gtk.Label currentValue2;
+    [Gtk.Connect] private Gtk.Label changePercentage2;
 
     // Graph
-    [Gtk.Connect] private readonly Adw.ToggleGroup rangeToggles;
-    [Gtk.Connect] private readonly Adw.Bin chartContainer;
-    [Gtk.Connect] private readonly Adw.Bin rangeGroupDropdown;
+    [Gtk.Connect] private Adw.ToggleGroup rangeToggles;
+    [Gtk.Connect] private Adw.Bin chartContainer;
+    [Gtk.Connect] private Adw.Bin rangeGroupDropdown;
 
     // Details
-    [Gtk.Connect] private readonly Gtk.Label open;
-    [Gtk.Connect] private readonly Gtk.Label high;
-    [Gtk.Connect] private readonly Gtk.Label low;
-    [Gtk.Connect] private readonly Gtk.Label marketStatus;
-    [Gtk.Connect] private readonly Gtk.Label open2;
-    [Gtk.Connect] private readonly Gtk.Label high2;
-    [Gtk.Connect] private readonly Gtk.Label low2;
-    [Gtk.Connect] private readonly Gtk.Label marketStatus2;
+    [Gtk.Connect] private Gtk.Label open;
+    [Gtk.Connect] private Gtk.Label high;
+    [Gtk.Connect] private Gtk.Label low;
+    [Gtk.Connect] private Gtk.Label marketStatus;
+    [Gtk.Connect] private Gtk.Label open2;
+    [Gtk.Connect] private Gtk.Label high2;
+    [Gtk.Connect] private Gtk.Label low2;
+    [Gtk.Connect] private Gtk.Label marketStatus2;
 
     // Footer
-    [Gtk.Connect] private readonly Gtk.Grid narrowFooter;
-    [Gtk.Connect] private readonly Gtk.Grid wideFooter;
+    [Gtk.Connect] private Gtk.Grid narrowFooter;
+    [Gtk.Connect] private Gtk.Grid wideFooter;
 
-    [Gtk.Connect] private readonly Gtk.Label updatedLabel;
-    [Gtk.Connect] private readonly Gtk.Label readMore;
+    [Gtk.Connect] private Gtk.Label updatedLabel;
+    [Gtk.Connect] private Gtk.Label readMore;
 
     private bool isNarrow = false;
     private bool isEditingAlias = false;
     private Ticker? activeTicker;
-    private KeyValueDropDown rangeDropdown;
+    private KeyValueDropDown rangeDropdown = null!;
     private readonly PeriodicTimer timer = new(System.TimeSpan.FromSeconds(1));
     
-    private AppModel model;
-    private TickerChart chart;
-    private Gtk.Overlay chartOverlay;
-    private Adw.StatusPage noDataView;
+    private AppModel model = null!;
+    private TickerChart chart = null!;
+    private Gtk.Overlay chartOverlay = null!;
+    private Adw.StatusPage noDataView = null!;
     private Action<Ticker>? updateHandler;
 
-    private TickerDetails(Gtk.Builder builder, string name) : base(new Gtk.Internal.BoxHandle(builder.GetPointer(name), false))
+    public static TickerDetails NewWithModel(AppModel model)
     {
-        builder.Connect(this);
+        var details = NewWithProperties([]);
+        details.SetModel(model);
+
+        return details;
     }
 
-    public TickerDetails(AppModel model) : this(Builder.FromFile("TickerDetails.ui"), "tickerDetails")
+    private void SetModel(AppModel model)
     {
         this.model = model;
 

--- a/Stocks/Ui/EmptyView.cs
+++ b/Stocks/Ui/EmptyView.cs
@@ -5,25 +5,28 @@ using Stocks.Model;
 
 namespace Stocks.UI;
 
-public class EmptyView : Gtk.Box
+[GObject.Subclass<Gtk.Box>(qualifiedName: nameof(EmptyView))]
+[Gtk.Template<Gtk.AssemblyResource>("EmptyView.ui")]
+public partial class EmptyView
 {
-    [Gtk.Connect] private readonly Adw.ToolbarView emptyView;
-    [Gtk.Connect] private readonly Adw.HeaderBar header;
-    [Gtk.Connect] private readonly Gtk.Button addSymbolButton;
-    [Gtk.Connect] private readonly Gtk.MenuButton menuButton;
+    [Gtk.Connect] private Adw.HeaderBar header;
+    [Gtk.Connect] private Gtk.Button addSymbolButton;
+    [Gtk.Connect] private Gtk.MenuButton menuButton;
 
-    private readonly AppModel model;
+    private AppModel? model;
 
-    private EmptyView(Gtk.Builder builder) : base()
+    public static EmptyView NewWithModel(AppModel model)
     {
-        builder.Connect(this);
-        Hexpand = true;
-        Vexpand = true;
-        Append(emptyView!);
+        var view = NewWithProperties([]);
+        view.SetModel(model);
+        return view;
     }
 
-    public EmptyView(AppModel model): this(Builder.FromFile("EmptyView.ui"))
+    private void SetModel(AppModel model)
     {
+        if (this.model is not null)
+            throw new InvalidOperationException("EmptyView dependencies have already been set.");
+
         this.model = model;
         header.PackStart(new AddButton(model));
         header.ShowTitle = true;

--- a/Stocks/Ui/Grid/GridView.cs
+++ b/Stocks/Ui/Grid/GridView.cs
@@ -5,36 +5,37 @@ using Stocks.Model;
 
 namespace Stocks.UI;
 
-public class GridView : Gtk.Box
+[GObject.Subclass<Gtk.Box>(qualifiedName: nameof(GridView))]
+[Gtk.Template<Gtk.AssemblyResource>("GridView.ui")]
+public partial class GridView
 {
-    [Gtk.Connect] private readonly Adw.NavigationView gridView;
-    [Gtk.Connect] private readonly Adw.NavigationPage detailsContent;
-    [Gtk.Connect] private readonly Gtk.ScrolledWindow scrollContainer;
-    [Gtk.Connect] private readonly Adw.Bin detailsContainer;
-    [Gtk.Connect] private readonly Adw.Banner errorBanner;
-    [Gtk.Connect] private readonly Adw.HeaderBar gridHeader;
-    [Gtk.Connect] private readonly Gtk.MenuButton menuButton;
-    [Gtk.Connect] private readonly Gtk.MenuButton detailsMenuButton;
-    [Gtk.Connect] private readonly Adw.HeaderBar detailsHeader;
+    [Gtk.Connect] private Adw.NavigationView gridView;
+    [Gtk.Connect] private Adw.NavigationPage detailsContent;
+    [Gtk.Connect] private Gtk.ScrolledWindow scrollContainer;
+    [Gtk.Connect] private Adw.Bin detailsContainer;
+    [Gtk.Connect] private Adw.Banner errorBanner;
+    [Gtk.Connect] private Adw.HeaderBar gridHeader;
+    [Gtk.Connect] private Gtk.MenuButton menuButton;
+    [Gtk.Connect] private Gtk.MenuButton detailsMenuButton;
+    [Gtk.Connect] private Adw.HeaderBar detailsHeader;
 
-    private readonly AppModel model;
-    private readonly TickerDetails details;
+    private AppModel model = null!;
+    private TickerDetails details = null!;
     private readonly HashSet<Ticker> observedTickers = [];
     private bool isNarrow;
 
-    private GridView(Gtk.Builder builder) : base()
+    public static GridView NewWithModel(AppModel model)
     {
-        builder.Connect(this);
-        Hexpand = true;
-        Vexpand = true;
-        Append(gridView!);
+        var view = NewWithProperties([]);
+        view.SetModel(model);
+        return view;
     }
 
-    public GridView(AppModel model): this(Builder.FromFile("GridView.ui"))
+    private void SetModel(AppModel model)
     {
         this.model = model;
 
-        details = new TickerDetails(model);
+        details = TickerDetails.NewWithModel(model);
         detailsContainer.SetChild(details);
 
         var tickerGrid = new TickerGrid(model);

--- a/Stocks/Ui/Grid/TickerGrid.cs
+++ b/Stocks/Ui/Grid/TickerGrid.cs
@@ -76,7 +76,7 @@ public class TickerGrid : Gtk.FlowBox
         var aspectFrame = Gtk.AspectFrame.New(0.5f, 0.5f, 1.0f, false);
         aspectFrame.WidthRequest = cardSize;
         aspectFrame.HeightRequest = cardSize;
-        aspectFrame.SetChild(new TickerGridCard(ticker));
+        aspectFrame.SetChild(TickerGridCard.NewWithTicker(ticker));
 
         return aspectFrame;
     }

--- a/Stocks/Ui/Grid/TickerGridCard.cs
+++ b/Stocks/Ui/Grid/TickerGridCard.cs
@@ -5,26 +5,29 @@ using Stocks.Model;
 
 namespace Stocks.UI;
 
-public class TickerGridCard : Gtk.Box
+[GObject.Subclass<Gtk.Box>(qualifiedName: nameof(TickerGridCard))]
+[Gtk.Template<Gtk.AssemblyResource>("TickerGridCard.ui")]
+public partial class TickerGridCard
 {
-    [Gtk.Connect] private readonly Gtk.Label displayName;
-    [Gtk.Connect] private readonly Gtk.Label name;
-    [Gtk.Connect] private readonly Gtk.Label value;
-    [Gtk.Connect] private readonly Gtk.Label change;
-    [Gtk.Connect] private readonly Adw.Bin chartBin;
+    [Gtk.Connect] private Gtk.Label displayName;
+    [Gtk.Connect] private Gtk.Label name;
+    [Gtk.Connect] private Gtk.Label value;
+    [Gtk.Connect] private Gtk.Label change;
+    [Gtk.Connect] private Adw.Bin chartBin;
 
-    private readonly TickerChart chart;
+    private TickerChart chart = null!;
 
-    public Ticker Ticker { get; }
+    public Ticker Ticker { get; private set; } = null!;
 
-    private TickerGridCard(Gtk.Builder builder, string name)
-        : base(new Gtk.Internal.BoxHandle(builder.GetPointer(name), false))
+    public static TickerGridCard NewWithTicker(Ticker ticker)
     {
-        builder.Connect(this);
+        var card = NewWithProperties([]);
+        card.SetTicker(ticker);
+
+        return card;
     }
 
-    public TickerGridCard(Ticker ticker)
-        : this(Builder.FromFile("TickerGridCard.ui"), "ticker-grid-card")
+    private void SetTicker(Ticker ticker)
     {
         Ticker = ticker;
         TickerContextMenu.Attach(this, Ticker);

--- a/Stocks/Ui/MainWindow.cs
+++ b/Stocks/Ui/MainWindow.cs
@@ -5,36 +5,39 @@ using Stocks.Model;
 
 namespace Stocks.UI;
 
-public class MainWindow : Adw.ApplicationWindow
+[GObject.Subclass<Adw.ApplicationWindow>(qualifiedName: nameof(MainWindow))]
+[Gtk.Template<Gtk.AssemblyResource>("MainWindow.ui")]
+public partial class MainWindow
 {
-    [Gtk.Connect] private readonly Gtk.Stack stack;
+    [Gtk.Connect] private Gtk.Stack stack;
 
-    private readonly AppModel model;
-    private readonly AppTheme theme;
-    private readonly AppMode mode;
-    private readonly SplitView splitView;
-    private readonly GridView gridView;
-    private readonly EmptyView emptyView;
+    private AppModel model = null!;
+    private AppTheme theme = null!;
+    private AppMode mode = null!;
+    private SplitView splitView = null!;
+    private GridView gridView = null!;
+    private EmptyView emptyView = null!;
 
     private bool isNarrow = false;
 
-    private MainWindow(Gtk.Builder builder, string name)
-        : base(new Adw.Internal.ApplicationWindowHandle(builder.GetPointer(name), false))
+    public static MainWindow NewWithModel(Adw.Application application, AppModel model, Gio.Settings settings)
     {
-        builder.Connect(this);
+        var window = NewWithProperties([]);
+        window.SetModel(application, model, settings);
+
+        return window;
     }
 
-    public MainWindow(Adw.Application application, AppModel model, Gio.Settings settings)
-        : this(Builder.FromFile("MainWindow.ui"), "mainWindow")
+    private void SetModel(Adw.Application application, AppModel model, Gio.Settings settings)
     {
         this.model = model;
         Application = application;
 
         theme = new AppTheme(settings);
         mode = new AppMode(settings);
-        splitView = new SplitView(model, this);
-        gridView = new GridView(model);
-        emptyView = new EmptyView(model);
+        splitView = SplitView.NewWithModel(model, this);
+        gridView = GridView.NewWithModel(model);
+        emptyView = EmptyView.NewWithModel(model);
 
         stack.AddNamed(splitView, "split");
         stack.AddNamed(gridView, "grid");
@@ -94,8 +97,8 @@ public class MainWindow : Adw.ApplicationWindow
             controls.Hexpand = true;
             controls.Halign = Gtk.Align.Fill;
 
-            var themeSwitcher = new ThemeSwitcher(theme);
-            var modeSwitcher = new BrowseModeSwitcher(mode);
+            var themeSwitcher = ThemeSwitcher.NewWithModel(theme);
+            var modeSwitcher = BrowseModeSwitcher.NewWithModel(mode);
             var separator = Gtk.Separator.New(Gtk.Orientation.Horizontal);
 
             themeSwitcher.Hexpand = true;

--- a/Stocks/Ui/PrimaryMenu/BrowseModeSwitcher.cs
+++ b/Stocks/Ui/PrimaryMenu/BrowseModeSwitcher.cs
@@ -4,22 +4,25 @@ using Stocks.Model;
 
 namespace Stocks.UI;
 
-public class BrowseModeSwitcher : Gtk.Box
+[GObject.Subclass<Gtk.Box>(qualifiedName: nameof(BrowseModeSwitcher))]
+[Gtk.Template<Gtk.AssemblyResource>("BrowseModeSwitcher.ui")]
+public partial class BrowseModeSwitcher
 {
-    [Gtk.Connect] private readonly Gtk.ToggleButton listButton;
-    [Gtk.Connect] private readonly Gtk.ToggleButton gridButton;
+    [Gtk.Connect] private Gtk.ToggleButton listButton;
+    [Gtk.Connect] private Gtk.ToggleButton gridButton;
 
-    private readonly AppMode model;
+    private AppMode model = null!;
     private bool syncingUi;
 
-    private BrowseModeSwitcher(Gtk.Builder builder, string name)
-        : base(new Gtk.Internal.BoxHandle(builder.GetPointer(name), false))
+    public static BrowseModeSwitcher NewWithModel(AppMode model)
     {
-        builder.Connect(this);
+        var switcher = NewWithProperties([]);
+        switcher.SetModel(model);
+
+        return switcher;
     }
 
-    public BrowseModeSwitcher(AppMode model)
-        : this(Builder.FromFile("BrowseModeSwitcher.ui"), "browseModeSwitcher")
+    private void SetModel(AppMode model)
     {
         this.model = model;
 

--- a/Stocks/Ui/PrimaryMenu/ThemeSwitcher.cs
+++ b/Stocks/Ui/PrimaryMenu/ThemeSwitcher.cs
@@ -4,21 +4,26 @@ using Stocks.Model;
 
 namespace Stocks.UI;
 
-public class ThemeSwitcher : Gtk.Box 
+[GObject.Subclass<Gtk.Box>(qualifiedName: nameof(ThemeSwitcher))]
+[Gtk.Template<Gtk.AssemblyResource>("ThemeSwitcher.ui")]
+public partial class ThemeSwitcher
 {
-    [Gtk.Connect] private readonly Gtk.CheckButton system;
-    [Gtk.Connect] private readonly Gtk.CheckButton light;
-    [Gtk.Connect] private readonly Gtk.CheckButton dark;
+    [Gtk.Connect] private Gtk.CheckButton system;
+    [Gtk.Connect] private Gtk.CheckButton light;
+    [Gtk.Connect] private Gtk.CheckButton dark;
 
-    private readonly AppTheme model;
+    private AppTheme model = null!;
     private bool syncingUi = false;
 
-    private ThemeSwitcher(Gtk.Builder builder, string name) : base(new Gtk.Internal.BoxHandle(builder.GetPointer(name), false))
+    public static ThemeSwitcher NewWithModel(AppTheme model)
     {
-        builder.Connect(this);
+        var switcher = NewWithProperties([]);
+        switcher.SetModel(model);
+
+        return switcher;
     }
 
-    public ThemeSwitcher(AppTheme model) : this(Builder.FromFile("ThemeSwitcher.ui"), "themeSwitcher")
+    private void SetModel(AppTheme model)
     {
         this.model = model;
 

--- a/Stocks/Ui/Sidebar/Sidebar.cs
+++ b/Stocks/Ui/Sidebar/Sidebar.cs
@@ -211,7 +211,7 @@ public class Sidebar: Gtk.ListBox
 
     private Gtk.Widget CreatePreviewFor(Ticker ticker, int width, int height)
     {
-        var content = new SidebarItem(
+        var content = SidebarItem.NewWithTicker(
             Gtk.SizeGroup.New(Gtk.SizeGroupMode.Horizontal),
             Gtk.SizeGroup.New(Gtk.SizeGroupMode.Horizontal),
             Gtk.SizeGroup.New(Gtk.SizeGroupMode.Horizontal),
@@ -237,7 +237,7 @@ public class Sidebar: Gtk.ListBox
 
     private void Add(Ticker ticker)
     {
-        var item = new SidebarItem(g1, g2, g3, ticker);
+        var item = SidebarItem.NewWithTicker(g1, g2, g3, ticker);
         items[ticker.Symbol] = item;
 
         var row = Gtk.ListBoxRow.New();

--- a/Stocks/Ui/Sidebar/SidebarItem.cs
+++ b/Stocks/Ui/Sidebar/SidebarItem.cs
@@ -5,24 +5,29 @@ using Stocks.Model;
 
 namespace Stocks.UI;
 
-public class SidebarItem : Gtk.Grid
+[GObject.Subclass<Gtk.Grid>(qualifiedName: nameof(SidebarItem))]
+[Gtk.Template<Gtk.AssemblyResource>("SidebarItem.ui")]
+public partial class SidebarItem
 {
-    [Gtk.Connect] private readonly Gtk.Label symbol;
-    [Gtk.Connect] private readonly Gtk.Label name;
-    [Gtk.Connect] private readonly Gtk.Label value;
-    [Gtk.Connect] private readonly Gtk.Label change;
-    [Gtk.Connect] private readonly Adw.Bin chartBin;
+    [Gtk.Connect] private Gtk.Label symbol;
+    [Gtk.Connect] private Gtk.Label name;
+    [Gtk.Connect] private Gtk.Label value;
+    [Gtk.Connect] private Gtk.Label change;
+    [Gtk.Connect] private Adw.Bin chartBin;
 
-    private readonly TickerChart chart;
+    private TickerChart chart = null!;
 
-    public Ticker Ticker { get; private set; }
+    public Ticker Ticker { get; private set; } = null!;
   
-    private SidebarItem(Gtk.Builder builder, string name) : base(new Gtk.Internal.GridHandle(builder.GetPointer(name), false))
+    public static SidebarItem NewWithTicker(Gtk.SizeGroup g1, Gtk.SizeGroup g2, Gtk.SizeGroup g3, Ticker ticker)
     {
-        builder.Connect(this);
+        var item = NewWithProperties([]);
+        item.SetTicker(g1, g2, g3, ticker);
+
+        return item;
     }
 
-    public SidebarItem(Gtk.SizeGroup g1, Gtk.SizeGroup g2, Gtk.SizeGroup g3, Ticker ticker) : this(Builder.FromFile("SidebarItem.ui"), "sidebar-item")
+    private void SetTicker(Gtk.SizeGroup g1, Gtk.SizeGroup g2, Gtk.SizeGroup g3, Ticker ticker)
     {
         // Add widgets to groups so that GTK can align these over all sidebar items.
         g1.AddWidget(symbol);

--- a/Stocks/Ui/Sidebar/SplitView.cs
+++ b/Stocks/Ui/Sidebar/SplitView.cs
@@ -2,42 +2,43 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Stocks.Model;
+using static Stocks.Translations;
 
 namespace Stocks.UI;
 
-public class SplitView : Gtk.Box
+[GObject.Subclass<Gtk.Box>(qualifiedName: nameof(SplitView))]
+[Gtk.Template<Gtk.AssemblyResource>("SplitView.ui")]
+public partial class SplitView
 {
-    [Gtk.Connect] private readonly Adw.NavigationSplitView splitView;
-    [Gtk.Connect] private readonly Gtk.ScrolledWindow sidebarContainer;
-    [Gtk.Connect] private readonly Adw.Bin detailsContainer;
-    [Gtk.Connect] private readonly Adw.Banner errorBanner;
-    [Gtk.Connect] private readonly Adw.HeaderBar sidebarHeader;
-    [Gtk.Connect] private readonly Adw.ToastOverlay toastOverlay;
-    [Gtk.Connect] private readonly Gtk.MenuButton menuButton;
-    [Gtk.Connect] private readonly Adw.NavigationPage detailsContent;
-    [Gtk.Connect] private readonly Adw.HeaderBar detailsHeader;
+    [Gtk.Connect] private Adw.NavigationSplitView splitView;
+    [Gtk.Connect] private Gtk.ScrolledWindow sidebarContainer;
+    [Gtk.Connect] private Adw.Bin detailsContainer;
+    [Gtk.Connect] private Adw.Banner errorBanner;
+    [Gtk.Connect] private Adw.HeaderBar sidebarHeader;
+    [Gtk.Connect] private Adw.ToastOverlay toastOverlay;
+    [Gtk.Connect] private Gtk.MenuButton menuButton;
+    [Gtk.Connect] private Adw.NavigationPage detailsContent;
+    [Gtk.Connect] private Adw.HeaderBar detailsHeader;
 
-    private readonly AppModel model;
-    private readonly Sidebar sidebar;
-    private readonly TickerDetails details;
+    private AppModel model = null!;
+    private Sidebar sidebar = null!;
+    private TickerDetails details = null!;
     private readonly HashSet<Ticker> observedTickers = [];
     private bool isNarrow;
 
-    private SplitView(Gtk.Builder builder): base()
+    public static SplitView NewWithModel(AppModel model, Adw.ApplicationWindow window)
     {
-        builder.Connect(this);
-        Hexpand = true;
-        Vexpand = true;
-        splitView!.Hexpand = true;
-        splitView.Vexpand = true;
-        Append(splitView);
+        var view = NewWithProperties([]);
+        view.SetModel(model, window);
+
+        return view;
     }
 
-    public SplitView(AppModel model, Adw.ApplicationWindow window): this(Builder.FromFile("SplitView.ui"))
+    private void SetModel(AppModel model, Adw.ApplicationWindow window)
     {
         this.model = model;
 
-        details = new TickerDetails(model);
+        details = TickerDetails.NewWithModel(model);
         detailsContainer.SetChild(details);
 
         sidebar = new Sidebar(model);

--- a/Stocks/Ui/Watchlists/WatchlistButton.cs
+++ b/Stocks/Ui/Watchlists/WatchlistButton.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Stocks.Model;
+using static Stocks.Translations;
 
 namespace Stocks.UI;
 

--- a/Stocks/Ui/Watchlists/WatchlistManageDialog.cs
+++ b/Stocks/Ui/Watchlists/WatchlistManageDialog.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Stocks.Model;
+using static Stocks.Translations;
 
 namespace Stocks.UI;
 

--- a/Stocks/Utils/Builder.cs
+++ b/Stocks/Utils/Builder.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using System.Xml;
+using static Stocks.Translations;
 
 // Borrowed from https://github.com/NickvisionApps/Denaro/blob/main/NickvisionMoney.GNOME/Helpers/Builder.cs
 public class Builder

--- a/data/ui/BrowseModeSwitcher.blp
+++ b/data/ui/BrowseModeSwitcher.blp
@@ -3,7 +3,7 @@
 
 using Gtk 4.0;
 
-Box browseModeSwitcher {
+template $BrowseModeSwitcher : Gtk.Box {
     styles [ "browsemode-switcher" ]
     hexpand: true;
     halign: fill;

--- a/data/ui/EmptyView.blp
+++ b/data/ui/EmptyView.blp
@@ -4,47 +4,59 @@
 using Gtk 4.0;
 using Adw 1;
 
-Adw.ToolbarView emptyView {
-	[top]
-	Adw.HeaderBar header {
-		show-title: false;
+template $EmptyView : Gtk.Box {
+	orientation: vertical;
+	hexpand: true;
+	vexpand: true;
 
-		// Add button is injected here [start]
-
-		[end]
-		MenuButton menuButton {
-			tooltip-text: _("Main Menu");
-			icon-name: "open-menu-symbolic";
-			menu-model: primaryMenu;
-			primary: true;
-		}
-	}
-
-	content: Adw.StatusPage {
-		icon-name: "emblem-important-symbolic";
-		title: _("No symbols");
-		description: _("Add symbol to your watchlist.");
+	Adw.ToolbarView {
 		hexpand: true;
 		vexpand: true;
-		halign: center;
-		valign: center;
-		width-request: 350;
 
-		child: Box {
-			orientation: vertical;
-			spacing: 12;
-			halign: center;
+		[top]
+		Adw.HeaderBar header {
+			show-title: false;
 
-			Button addSymbolButton {
-				css-classes: ["suggested-action", "pill"];
+			// Add button is injected here [start]
 
-				child: Adw.ButtonContent {
-					icon-name: "list-add-symbolic";
-					label: _("Add symbol");
-				};
+			[end]
+			MenuButton menuButton {
+				tooltip-text: _("Main Menu");
+				icon-name: "open-menu-symbolic";
+				menu-model: primaryMenu;
+				primary: true;
 			}
+		}
+
+		content: Adw.StatusPage {
+			icon-name: "emblem-important-symbolic";
+			title: _("No symbols");
+			description: _("Add symbol to your watchlist.");
+			hexpand: true;
+			vexpand: true;
+			halign: center;
+			valign: center;
+			width-request: 350;
+
+			child: Box {
+				orientation: vertical;
+				spacing: 12;
+				halign: center;
+
+				Button addSymbolButton {
+					accessibility {
+					  label: _("Add symbol");
+					}
+					css-classes: ["suggested-action", "pill"];
+
+					child: Adw.ButtonContent {
+						icon-name: "list-add-symbolic";
+						label: _("Add symbol");
+					};
+				}
+			};
 		};
-	};
+	}
 }
 
 menu primaryMenu {

--- a/data/ui/GridView.blp
+++ b/data/ui/GridView.blp
@@ -4,63 +4,72 @@
 using Gtk 4.0;
 using Adw 1;
 
-Adw.NavigationView gridView {
-	Adw.NavigationPage {
-		title: _("Symbols");
-		tag: "grid";
+template $GridView : Gtk.Box {
+	orientation: vertical;
+	hexpand: true;
+	vexpand: true;
 
-		child: Adw.ToolbarView {
-			[top]
-			Adw.HeaderBar gridHeader {
-				show-title: false;
-				// Add button is injected here [start]
+	Adw.NavigationView gridView {
+		hexpand: true;
+		vexpand: true;
 
-				[end]
-				MenuButton menuButton {
-					tooltip-text: _("Main Menu");
-					icon-name: "open-menu-symbolic";
-					menu-model: primaryMenu;
-					primary: true;
+		Adw.NavigationPage {
+			title: _("Symbols");
+			tag: "grid";
+
+			child: Adw.ToolbarView {
+				[top]
+				Adw.HeaderBar gridHeader {
+					show-title: false;
+					// Add button is injected here [start]
+
+					[end]
+					MenuButton menuButton {
+						tooltip-text: _("Main Menu");
+						icon-name: "open-menu-symbolic";
+						menu-model: primaryMenu;
+						primary: true;
+					}
 				}
-			}
 
-			content: ScrolledWindow scrollContainer {
-				hscrollbar-policy: never;
+				content: ScrolledWindow scrollContainer {
+					hscrollbar-policy: never;
+				};
 			};
-		};
-	}
+		}
 
-	Adw.NavigationPage detailsContent {
-		title: _("Details");
-		tag: "details";
+		Adw.NavigationPage detailsContent {
+			title: _("Details");
+			tag: "details";
 
-		child: Adw.ToolbarView {
-			[top]
-			Adw.HeaderBar detailsHeader {
-				show-title: false;
+			child: Adw.ToolbarView {
+				[top]
+				Adw.HeaderBar detailsHeader {
+					show-title: false;
 
-				[end]
-				MenuButton detailsMenuButton {
-					tooltip-text: _("Main Menu");
-					icon-name: "open-menu-symbolic";
-					menu-model: primaryMenu;
-					primary: true;
-				}
-			}
-
-			content: Box {
-				orientation: vertical;
-
-				Adw.Banner errorBanner {
-					title: _("Refresh failed - Data can be stale");
-			  		revealed: false;
+					[end]
+					MenuButton detailsMenuButton {
+						tooltip-text: _("Main Menu");
+						icon-name: "open-menu-symbolic";
+						menu-model: primaryMenu;
+						primary: true;
+					}
 				}
 
-				Adw.Bin detailsContainer {
-					// Details is injected here.
-				}
+				content: Box {
+					orientation: vertical;
+
+					Adw.Banner errorBanner {
+						title: _("Refresh failed - Data can be stale");
+				  		revealed: false;
+					}
+
+					Adw.Bin detailsContainer {
+						// Details is injected here.
+					}
+				};
 			};
-		};
+		}
 	}
 }
 

--- a/data/ui/MainWindow.blp
+++ b/data/ui/MainWindow.blp
@@ -4,7 +4,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-Adw.ApplicationWindow mainWindow {
+template $MainWindow : Adw.ApplicationWindow {
 	default-width: 1050;
 	default-height: 655;
 	width-request: 355;

--- a/data/ui/SidebarItem.blp
+++ b/data/ui/SidebarItem.blp
@@ -4,7 +4,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-Grid sidebar-item {
+template $SidebarItem : Gtk.Grid {
     margin-top: 8;
     margin-bottom: 8;
     margin-start: 0;

--- a/data/ui/SplitView.blp
+++ b/data/ui/SplitView.blp
@@ -4,61 +4,69 @@
 using Gtk 4.0;
 using Adw 1;
 
-Adw.NavigationSplitView splitView {
-	min-sidebar-width: 300;
-	max-sidebar-width: 300;
+template $SplitView : Gtk.Box {
+	orientation: vertical;
+	hexpand: true;
+	vexpand: true;
 
-	// Sidebar
-	sidebar: Adw.NavigationPage {
-		title: _("Symbols");
-		child: Adw.ToastOverlay toastOverlay {
-			Adw.ToolbarView {
-				[top]
-				Adw.HeaderBar sidebarHeader {
-					show-title: false;
-					// Add button is injected here
-				}
+	Adw.NavigationSplitView splitView {
+		hexpand: true;
+		vexpand: true;
+		min-sidebar-width: 300;
+		max-sidebar-width: 300;
 
-				content: ScrolledWindow sidebarContainer {
-					hscrollbar-policy: never;
-				};
-			}
-		};
-	};
+		// Sidebar
+		sidebar: Adw.NavigationPage {
+			title: _("Symbols");
+			child: Adw.ToastOverlay toastOverlay {
+				Adw.ToolbarView {
+					[top]
+					Adw.HeaderBar sidebarHeader {
+						show-title: false;
+						// Add button is injected here
+					}
 
-	// Content
-	content: Adw.NavigationPage detailsContent {
-		title: _("Details");
-		tag: "details";
-
-		child: Adw.ToolbarView {
-			[top]
-			Adw.HeaderBar detailsHeader {
-				show-title: false;
-
-				[end]
-				MenuButton menuButton {
-					tooltip-text: _("Main Menu");
-					icon-name: "open-menu-symbolic";
-					menu-model: primaryMenu;
-					primary: true;
-				}
-			}
-
-			content: Box {
-				orientation: vertical;
-
-				Adw.Banner errorBanner {
-					title: _("Refresh failed - Data can be stale");
-			  		revealed: false;
-				}
-
-				Adw.Bin detailsContainer {
-					// Details is injected here.
+					content: ScrolledWindow sidebarContainer {
+						hscrollbar-policy: never;
+					};
 				}
 			};
 		};
-	};
+
+		// Content
+		content: Adw.NavigationPage detailsContent {
+			title: _("Details");
+			tag: "details";
+
+			child: Adw.ToolbarView {
+				[top]
+				Adw.HeaderBar detailsHeader {
+					show-title: false;
+
+					[end]
+					MenuButton menuButton {
+						tooltip-text: _("Main Menu");
+						icon-name: "open-menu-symbolic";
+						menu-model: primaryMenu;
+						primary: true;
+					}
+				}
+
+				content: Box {
+					orientation: vertical;
+
+					Adw.Banner errorBanner {
+						title: _("Refresh failed - Data can be stale");
+				  		revealed: false;
+					}
+
+					Adw.Bin detailsContainer {
+						// Details is injected here.
+					}
+				};
+			};
+		};
+	}
 }
 
 menu primaryMenu {

--- a/data/ui/ThemeSwitcher.blp
+++ b/data/ui/ThemeSwitcher.blp
@@ -5,7 +5,7 @@
 
 using Gtk 4.0;
 
-Box themeSwitcher {
+template $ThemeSwitcher : Gtk.Box {
     styles [
         "themeswitcher",
     ]

--- a/data/ui/TickerDetails.blp
+++ b/data/ui/TickerDetails.blp
@@ -4,7 +4,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-Box tickerDetails { 
+template $TickerDetails : Gtk.Box { 
     margin-top: 8;
     margin-start: 20;
     margin-end: 20;

--- a/data/ui/TickerGridCard.blp
+++ b/data/ui/TickerGridCard.blp
@@ -4,7 +4,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-Box ticker-grid-card {
+template $TickerGridCard : Gtk.Box {
     css-classes: [ "card" ];
     orientation: vertical;
     spacing: 8;


### PR DESCRIPTION
This is a technical maintanance upgrade of [Gir.Core](https://gircore.github.io/index.html) C# language bindings. No functional changes to the app.

Switched to use [Blueprint composite templates](https://gnome.pages.gitlab.gnome.org/blueprint-compiler/reference/templates.html) since the support was added to gir.core in 0.8.0.

This required a new pattern to inject models into custom views, since constructors are not used anymore. Unfortunately this change forced me to change many `readonly` class variables to writable. Not a big deal, but some compile time safety was lost in the process.
