### PR TITLE
Cleaning: Compiler warnings

### DIFF
--- a/Stocks.csproj
+++ b/Stocks.csproj
@@ -14,7 +14,8 @@
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>false</PublishTrimmed>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks> 
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Stocks/Model/Ticker.cs
+++ b/Stocks/Model/Ticker.cs
@@ -39,7 +39,7 @@ public class Ticker(string symbol, TickerFetcher fetcher, Market market)
     // This event is fired after data refresh so that UI knows to update it self.
     public event Action<Ticker>? OnUpdated;
 
-    public bool TryGetData(TickerRange range, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TickerData data) => datas.TryGetValue(range, out data);
+    public bool TryGetData(TickerRange range, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TickerData? data) => datas.TryGetValue(range, out data);
 
     // User can replace override symbol name in UI with an alias.
     public void SetAlias(string value)

--- a/Stocks/Model/Ticker.cs
+++ b/Stocks/Model/Ticker.cs
@@ -39,7 +39,7 @@ public class Ticker(string symbol, TickerFetcher fetcher, Market market)
     // This event is fired after data refresh so that UI knows to update it self.
     public event Action<Ticker>? OnUpdated;
 
-    public bool TryGetData(TickerRange range, out TickerData data) => datas.TryGetValue(range, out data);
+    public bool TryGetData(TickerRange range, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TickerData data) => datas.TryGetValue(range, out data);
 
     // User can replace override symbol name in UI with an alias.
     public void SetAlias(string value)

--- a/Stocks/Model/TickerDataExtensions.cs
+++ b/Stocks/Model/TickerDataExtensions.cs
@@ -7,7 +7,7 @@ public record Marker(DateTime Timestamp, string Label);
 
 public static class TickerRangeMarkerExtension
 {
-    public static (DateTime, TimeSpan, string) GetMarkerRules(this TickerRange range, DateTime start, TimeSpan? span = null)
+    public static (DateTime, TimeSpan, string) GetMarkerRules(this TickerRange range, DateTime start, TimeSpan span)
     {
         TickerRange GetClosestThreshold(TimeSpan timeSpan)
         {
@@ -77,7 +77,7 @@ public static class TickerRangeMarkerExtension
 
             case TickerRange.Ytd:
                 // Recursively use Day, FiveDays, Month, ThreeMonths, SixMonths or Year.
-                return GetClosestThreshold(span.Value).GetMarkerRules(start);
+                return GetClosestThreshold(span).GetMarkerRules(start, span);
 
             default:
                 throw new Exception("Scale mapping missing for TickerRange: " + range);

--- a/Stocks/Model/TickerDataExtensions.cs
+++ b/Stocks/Model/TickerDataExtensions.cs
@@ -109,7 +109,8 @@ public static class TickerDataExtensions
                 TickerRange.ThreeMonths => 1,
                 TickerRange.SixMonths => 2,
                 TickerRange.Year => 3,
-                TickerRange.TwoYears => 4
+                TickerRange.TwoYears => 4,
+                _ => 0 // Removes compiler warning, but will never be executed
             };
 
             while (current <= maxTime)
@@ -127,7 +128,8 @@ public static class TickerDataExtensions
             {
                 TickerRange.FiveYears => 1,
                 TickerRange.TenYears => 2,
-                TickerRange.All => 2
+                TickerRange.All => 2,
+                _ => 0 // Removes compiler warning, but will never be executed
             };
 
             while (current <= maxTime)

--- a/Stocks/Model/TickerDataParser.cs
+++ b/Stocks/Model/TickerDataParser.cs
@@ -9,8 +9,10 @@ public class TickerDataParser
     {
         var numberOfDecimals = result.Meta.PriceHint ?? 2;
 
-        var open = result.Indicators.Quote.FirstOrDefault()?.Open ?? [];
-        var close = result.Indicators.Quote.FirstOrDefault()?.Close ?? [];
+        var quote = result.Indicators.Quote;
+
+        var open = quote?.FirstOrDefault()?.Open ?? [];
+        var close = quote?.FirstOrDefault()?.Close ?? [];
 
         var closeValues = close.Where(v => v.HasValue).Select(v => v!.Value).ToArray();
         var fallbackPrice = result.Meta.RegularMarketPrice;

--- a/Stocks/Model/TickerDataParser.cs
+++ b/Stocks/Model/TickerDataParser.cs
@@ -103,17 +103,18 @@ public class TickerDataParser
     // is missing. This is the best we can do.
     private static double[] ReplaceNullsWithPrevious(double?[] data)
     {
-        if (data.Length == 0) return [];
+        if (data.Length == 0) 
+            return [];
         
         var result = new double[data.Length];
         double last = 0;
         
         for (int i = 0; i < data.Length; i++)
         {
-            if (data[i].HasValue)
+            if (data[i] is double x)
             {
-                last = data[i].Value;
-                result[i] = data[i].Value;
+                last = x;
+                result[i] = x;
             }
             else
             {

--- a/Stocks/Ui/AddTicker/AddButton.cs
+++ b/Stocks/Ui/AddTicker/AddButton.cs
@@ -6,14 +6,22 @@ using static Stocks.Translations;
 
 namespace Stocks.UI;
 
-public class AddButton : Gtk.Button
+[GObject.Subclass<Gtk.Button>(qualifiedName: nameof(AddButton))]
+public partial class AddButton
 {
     // If window is narrower than this treshold, add is shown as dialog instead of popover.
     private const int AddDialogThreshold = 370;
     
-    private readonly AppModel model;
+    private AppModel model = null!;
 
-    public AddButton(AppModel model)
+    public static AddButton NewWithModel(AppModel model)
+    {
+        var button = NewWithProperties([]);
+        button.SetModel(model);
+        return button;
+    }
+
+    private void SetModel(AppModel model)
     {
         TooltipText = _("Add symbol");
         IconName = "list-add-symbolic";
@@ -38,7 +46,7 @@ public class AddButton : Gtk.Button
 
     private void ShowAddPopover()
     {
-        var popover = new AddTickerPopover(model);
+        var popover = AddTickerPopover.NewWithModel(model);
         popover.SetParent(this);
         popover.Show();
     }
@@ -48,7 +56,7 @@ public class AddButton : Gtk.Button
         if (Root is not Gtk.Widget parent)
             return;
 
-        var dialog = new AddTickerDialog(model);
+        var dialog = AddTickerDialog.NewWithModel(model);
         dialog.Present(parent);
     }
 }

--- a/Stocks/Ui/AddTicker/AddTickerPopover.cs
+++ b/Stocks/Ui/AddTicker/AddTickerPopover.cs
@@ -6,20 +6,36 @@ using static Stocks.Translations;
 
 namespace Stocks.UI;
 
-class AddTickerPopover : Gtk.Popover
+[GObject.Subclass<Gtk.Popover>(qualifiedName: nameof(AddTickerPopover))]
+partial class AddTickerPopover
 {
-    public AddTickerPopover(AppModel model)
-    {        
-        var content = new AddTickerView(model, () => Hide());
+    public static AddTickerPopover NewWithModel(AppModel model)
+    {
+        var popover = NewWithProperties([]);
+        popover.SetModel(model);
+        return popover;
+    }
+
+    private void SetModel(AppModel model)
+    {
+        var content = AddTickerView.NewWithModel(model, () => Hide());
         SetChild(content);
     }
 }
 
-class AddTickerDialog: Adw.Dialog
+[GObject.Subclass<Adw.Dialog>(qualifiedName: nameof(AddTickerDialog))]
+partial class AddTickerDialog
 {
-    public AddTickerDialog(AppModel model)
+    public static AddTickerDialog NewWithModel(AppModel model)
     {
-        var content = new AddTickerView(model, () => Close());
+        var dialog = NewWithProperties([]);
+        dialog.SetModel(model);
+        return dialog;
+    }
+
+    private void SetModel(AppModel model)
+    {
+        var content = AddTickerView.NewWithModel(model, () => Close());
         content.MarginStart = 8;
         content.MarginEnd = 8;
         content.MarginTop = 8;
@@ -28,7 +44,8 @@ class AddTickerDialog: Adw.Dialog
     }
 }
 
-class AddTickerView : Gtk.Box
+[GObject.Subclass<Gtk.Box>(qualifiedName: nameof(AddTickerView))]
+partial class AddTickerView
 {
     private List<SearchResultListRow> results = [];
 
@@ -49,7 +66,14 @@ class AddTickerView : Gtk.Box
 
     private readonly Adw.StatusPage emptyState = Adw.StatusPage.New();
 
-    public AddTickerView(AppModel model, Action hideAction)
+    public static AddTickerView NewWithModel(AppModel model, Action hideAction)
+    {
+        var view = NewWithProperties([]);
+        view.SetModel(model, hideAction);
+        return view;
+    }
+
+    private void SetModel(AppModel model, Action hideAction)
     {
         var box = Gtk.Box.New(Gtk.Orientation.Vertical, 10);
 
@@ -113,7 +137,7 @@ class AddTickerView : Gtk.Box
 
                 results.ForEach(x => x.OnAdd -= AddTicker);
                 resultBox.RemoveAll();
-                results = result.Select(x => new SearchResultListRow(g1, g2, g3, model, x)).ToList();
+                results = result.Select(x => SearchResultListRow.NewWithResult(g1, g2, g3, model, x)).ToList();
                 results.ForEach(x => x.OnAdd += AddTicker);
                 results.ToList().ForEach(x => resultBox.Append(x));
                 return false;
@@ -163,11 +187,19 @@ class AddTickerView : Gtk.Box
         emptyState.Description = _("No results found for current search term.");
     }
 
-    private class SearchResultListRow: Gtk.ListBoxRow
+    [GObject.Subclass<Gtk.ListBoxRow>(qualifiedName: nameof(SearchResultListRow))]
+    internal partial class SearchResultListRow
     {
         public event Action<string>? OnAdd;
 
-        public SearchResultListRow(Gtk.SizeGroup g1, Gtk.SizeGroup g2, Gtk.SizeGroup g3, AppModel model, SearchResult result)
+        public static SearchResultListRow NewWithResult(Gtk.SizeGroup g1, Gtk.SizeGroup g2, Gtk.SizeGroup g3, AppModel model, SearchResult result)
+        {
+            var row = NewWithProperties([]);
+            row.SetResult(g1, g2, g3, model, result);
+            return row;
+        }
+
+        private void SetResult(Gtk.SizeGroup g1, Gtk.SizeGroup g2, Gtk.SizeGroup g3, AppModel model, SearchResult result)
         {
             Selectable = false;
 

--- a/Stocks/Ui/Details/Dropdown.cs
+++ b/Stocks/Ui/Details/Dropdown.cs
@@ -11,14 +11,22 @@ namespace Stocks.UI;
 /// The amount of code this takes is ridigilous... 
 /// maybe there is a better way?
 /// </summary>
-public class KeyValueDropDown: Gtk.DropDown
+[GObject.Subclass<Gtk.DropDown>(qualifiedName: nameof(KeyValueDropDown))]
+public partial class KeyValueDropDown
 {
     public event Action<string> OnValueSelected;
 
-    private IDictionary<string, string> items;
+    private IDictionary<string, string> items = new Dictionary<string, string>();
     private bool suppressSelectionNotifications = false;
 
-    public KeyValueDropDown(IDictionary<string, string> items)
+    public static KeyValueDropDown NewWithItems(IDictionary<string, string> items)
+    {
+        var dropdown = NewWithProperties([]);
+        dropdown.SetItemsModel(items);
+        return dropdown;
+    }
+
+    private void SetItemsModel(IDictionary<string, string> items)
     {
         this.items = items;
 

--- a/Stocks/Ui/Details/TickerChart.cs
+++ b/Stocks/Ui/Details/TickerChart.cs
@@ -53,7 +53,8 @@ public class ChartPalette {
             : new Color(0,0,0,1);
 }
 
-public class TickerChart: Gtk.DrawingArea
+[GObject.Subclass<Gtk.DrawingArea>(qualifiedName: nameof(TickerChart))]
+public partial class TickerChart
 {
     // Configuration
     public bool EnableMouseInteraction { get; set; } = true;
@@ -119,7 +120,12 @@ public class TickerChart: Gtk.DrawingArea
         OnHover?.Invoke(d1, d2, HoverMode == HoverMode.PopoverOnBottom);
     }
 
-    public TickerChart()
+    public static new TickerChart New()
+    {
+        return NewWithProperties([]);
+    }
+
+    partial void Initialize()
     {
         SetDrawFunc(Draw);
         TrackMouse();
@@ -145,7 +151,7 @@ public class TickerChart: Gtk.DrawingArea
     // Update chart state based on mouse actions (position and click)
     private void TrackMouse()
     {
-        var motion = new Gtk.EventControllerMotion();
+        var motion = Gtk.EventControllerMotion.New();
 
         motion.OnMotion += (o, args) =>
         {
@@ -243,7 +249,7 @@ public class TickerChart: Gtk.DrawingArea
 
     private void SetupPopover()
     {
-        popover = new TickerChartPopover();
+        popover = TickerChartPopover.New();
         popover.SetParent(this);
     }
 

--- a/Stocks/Ui/Details/TickerChart.cs
+++ b/Stocks/Ui/Details/TickerChart.cs
@@ -406,6 +406,9 @@ public partial class TickerChart
     {
         double min = 0;
         double max = 0;
+        
+        if (data == null)
+            return new (0,0);
 
         if (ShowPreviousCloseLine)
         {
@@ -424,6 +427,7 @@ public partial class TickerChart
     // Defines a current user selected range. (Click and hover action)
     DragRange? CreateDragRange(double dpWidth, double limitX) 
     {
+        if (data == null) return null;
         if (!isDragging) return null;
         if (dpWidth <= 0) return null;
 
@@ -476,7 +480,7 @@ public partial class TickerChart
         if (ShowXScale) DrawXScale(ctx); 
 
         /// Define the color to use when drawing non-muted parts of the graph
-        var color = drag?.Color ?? (data!.IsPositive ? palette.positive : palette.negative);
+        var color = drag?.Color ?? (data.IsPositive ? palette.positive : palette.negative);
 
         if (ShowPreviousCloseLine && !isDragging)
         {

--- a/Stocks/Ui/Details/TickerChartPopover.cs
+++ b/Stocks/Ui/Details/TickerChartPopover.cs
@@ -6,16 +6,22 @@ using static Stocks.Translations;
 
 namespace Stocks.UI;
 
-public class TickerChartPopover: Gtk.Popover
+[GObject.Subclass<Gtk.Popover>(qualifiedName: nameof(TickerChartPopover))]
+public partial class TickerChartPopover
 {
-    private readonly Gtk.Label dateTitle;
-    private readonly Gtk.Label dateValue;
-    private readonly Gtk.Label priceTitle;
-    private readonly Gtk.Label priceValue;
-    private readonly Gtk.Label changeTitle;
-    private readonly Gtk.Label changeValue;
+    private Gtk.Label dateTitle = null!;
+    private Gtk.Label dateValue = null!;
+    private Gtk.Label priceTitle = null!;
+    private Gtk.Label priceValue = null!;
+    private Gtk.Label changeTitle = null!;
+    private Gtk.Label changeValue = null!;
 
-    public TickerChartPopover()
+    public static new TickerChartPopover New()
+    {
+        return NewWithProperties([]);
+    }
+
+    partial void Initialize()
     {
         Autohide = false;
         HasArrow = true;

--- a/Stocks/Ui/Details/TickerDetails.cs
+++ b/Stocks/Ui/Details/TickerDetails.cs
@@ -155,7 +155,7 @@ public partial class TickerDetails
             items[key] = Enum.Parse<TickerRange>(key).GetDisplayName();
         }
 
-        rangeDropdown = new KeyValueDropDown(items);
+        rangeDropdown = KeyValueDropDown.NewWithItems(items);
         rangeDropdown.Hexpand = false;
         rangeDropdown.Halign = Gtk.Align.Start;
         rangeDropdown.OnValueSelected += SetRangeFromName;
@@ -200,21 +200,21 @@ public partial class TickerDetails
             }
         }
      
-        chart = new TickerChart { Vexpand = true, Hexpand = true };
+        chart = TickerChart.New();
+        chart.Vexpand = true;
+        chart.Hexpand = true;
         chart.OnHover += OnChartHover;
 
-        noDataView = new Adw.StatusPage
-        {
-            Title = _("Chart not available"),
-            IconName = "emblem-important-symbolic",
-            WidthRequest = 400,
-            Halign = Gtk.Align.Center,
-            Valign = Gtk.Align.Center,
-            Hexpand = true,
-            Vexpand = true
-        };
+        noDataView = Adw.StatusPage.New();
+        noDataView.Title = _("Chart not available");
+        noDataView.IconName = "emblem-important-symbolic";
+        noDataView.WidthRequest = 400;
+        noDataView.Halign = Gtk.Align.Center;
+        noDataView.Valign = Gtk.Align.Center;
+        noDataView.Hexpand = true;
+        noDataView.Vexpand = true;
 
-        chartOverlay = new Gtk.Overlay();
+        chartOverlay = Gtk.Overlay.New();
         chartOverlay.Hexpand = true;
         chartOverlay.SetChild(chart);
         chartOverlay.AddOverlay(noDataView);

--- a/Stocks/Ui/Details/TickerDetails.cs
+++ b/Stocks/Ui/Details/TickerDetails.cs
@@ -13,7 +13,7 @@ public partial class TickerDetails
     [Gtk.Connect] private Gtk.Box cardContent;
 
     // Main containers to switch between details / no-details
-    [Gtk.Connect] private Gtk.Box noDetails;
+    [Gtk.Connect] private Adw.Bin noDetails;
     [Gtk.Connect] private Adw.Clamp detailsCard;
     [Gtk.Connect] private Adw.Clamp detailsFooter;
 
@@ -23,7 +23,7 @@ public partial class TickerDetails
 
     [Gtk.Connect] private Gtk.Label name;
     [Gtk.Connect] private Gtk.Label symbol;
-    [Gtk.Connect] private Gtk.Box symbolDisplayBox;
+    [Gtk.Connect] private Adw.Bin symbolDisplayBox;
     [Gtk.Connect] private Gtk.Box symbolEditBox;
     [Gtk.Connect] private Gtk.Entry aliasEntry;
     [Gtk.Connect] private Gtk.Button aliasSaveButton;

--- a/Stocks/Ui/EmptyView.cs
+++ b/Stocks/Ui/EmptyView.cs
@@ -28,13 +28,13 @@ public partial class EmptyView
             throw new InvalidOperationException("EmptyView dependencies have already been set.");
 
         this.model = model;
-        header.PackStart(new AddButton(model));
+        header.PackStart(AddButton.NewWithModel(model));
         header.ShowTitle = true;
-        header.SetTitleWidget(new WatchlistButton(model.Watchlists));
+        header.SetTitleWidget(WatchlistButton.NewWithModel(model.Watchlists));
 
         addSymbolButton.OnClicked += (_, _) =>
         {
-            var dialog = new AddTickerDialog(model);
+            var dialog = AddTickerDialog.NewWithModel(model);
             dialog.Present(Root as Gtk.Widget);
         };
     }

--- a/Stocks/Ui/Grid/GridView.cs
+++ b/Stocks/Ui/Grid/GridView.cs
@@ -38,7 +38,7 @@ public partial class GridView
         details = TickerDetails.NewWithModel(model);
         detailsContainer.SetChild(details);
 
-        var tickerGrid = new TickerGrid(model);
+        var tickerGrid = TickerGrid.NewWithModel(model);
         tickerGrid.OnTickerActivated += ticker =>
         {
             model.SetActive(ticker);
@@ -47,9 +47,9 @@ public partial class GridView
         };
         scrollContainer.SetChild(tickerGrid);
 
-        gridHeader.PackStart(new AddButton(model));
+        gridHeader.PackStart(AddButton.NewWithModel(model));
         gridHeader.ShowTitle = true;
-        gridHeader.SetTitleWidget(new WatchlistButton(model.Watchlists));
+        gridHeader.SetTitleWidget(WatchlistButton.NewWithModel(model.Watchlists));
 
         SyncVisibleTickerSubscriptions();
 

--- a/Stocks/Ui/Grid/TickerGrid.cs
+++ b/Stocks/Ui/Grid/TickerGrid.cs
@@ -5,9 +5,10 @@ using Stocks.Model;
 
 namespace Stocks.UI;
 
-public class TickerGrid : Gtk.FlowBox
+[GObject.Subclass<Gtk.FlowBox>(qualifiedName: nameof(TickerGrid))]
+public partial class TickerGrid
 {
-    private readonly AppModel model;
+    private AppModel model = null!;
     private readonly Dictionary<string, Gtk.AspectFrame> cards = [];
 
     // Container for all on-going animations during drag operation
@@ -16,7 +17,14 @@ public class TickerGrid : Gtk.FlowBox
     private DragState? dragState;
     public event Action<Ticker>? OnTickerActivated;
 
-    public TickerGrid(AppModel model)
+    public static TickerGrid NewWithModel(AppModel model)
+    {
+        var grid = NewWithProperties([]);
+        grid.SetModel(model);
+        return grid;
+    }
+
+    private void SetModel(AppModel model)
     {
         this.model = model;
         this.model.Tickers.ForEach(AddTicker);

--- a/Stocks/Ui/Grid/TickerGridCard.cs
+++ b/Stocks/Ui/Grid/TickerGridCard.cs
@@ -32,18 +32,16 @@ public partial class TickerGridCard
         Ticker = ticker;
         TickerContextMenu.Attach(this, Ticker);
 
-        chart = new TickerChart
-        {
-            EnableMouseInteraction = false,
-            ShowDotOnHover = false,
-            ShowPreviousCloseLine = true,
-            ShowGradient = true,
-            ShowXScale = false,
-            ShowYScale = false,
-            LineWidth = 1.5,
-            Hexpand = true,
-            Vexpand = true
-        };
+        chart = TickerChart.New();
+        chart.EnableMouseInteraction = false;
+        chart.ShowDotOnHover = false;
+        chart.ShowPreviousCloseLine = true;
+        chart.ShowGradient = true;
+        chart.ShowXScale = false;
+        chart.ShowYScale = false;
+        chart.LineWidth = 1.5;
+        chart.Hexpand = true;
+        chart.Vexpand = true;
 
         chartBin.SetChild(chart);
 

--- a/Stocks/Ui/Sidebar/Sidebar.cs
+++ b/Stocks/Ui/Sidebar/Sidebar.cs
@@ -5,9 +5,10 @@ using Stocks.Model;
 
 namespace Stocks.UI;
 
-public class Sidebar: Gtk.ListBox
+[GObject.Subclass<Gtk.ListBox>(qualifiedName: nameof(Sidebar))]
+public partial class Sidebar
 {
-    private readonly AppModel model;
+    private AppModel model = null!;
     private readonly Dictionary<string, SidebarItem> items = [];
 
     public event Action<Ticker>? OnTickerActivated;
@@ -28,7 +29,14 @@ public class Sidebar: Gtk.ListBox
     private readonly Gtk.SizeGroup g2 = Gtk.SizeGroup.New(Gtk.SizeGroupMode.Horizontal);
     private readonly Gtk.SizeGroup g3 = Gtk.SizeGroup.New(Gtk.SizeGroupMode.Horizontal);
 
-    public Sidebar(AppModel model)
+    public static Sidebar NewWithModel(AppModel model)
+    {
+        var sidebar = NewWithProperties([]);
+        sidebar.SetModel(model);
+        return sidebar;
+    }
+
+    private void SetModel(AppModel model)
     {
         AddCssClass("navigation-sidebar");
 

--- a/Stocks/Ui/Sidebar/SidebarItem.cs
+++ b/Stocks/Ui/Sidebar/SidebarItem.cs
@@ -35,20 +35,18 @@ public partial class SidebarItem
         g2.AddWidget(chartBin);
         g3.AddWidget(value);
 
-        chart = new TickerChart
-        {
-            EnableMouseInteraction = false,
-            ShowDotOnHover = false,
-            ShowPreviousCloseLine = true,
-            ShowGradient = true,
-            ShowXScale = false,
-            ShowYScale = false,
-            LineWidth = 1,
-            CloseMarkerWidth = 1,
-            Padding = 1,
-            MarginTop = 10,
-            MarginBottom = 10
-        };
+        chart = TickerChart.New();
+        chart.EnableMouseInteraction = false;
+        chart.ShowDotOnHover = false;
+        chart.ShowPreviousCloseLine = true;
+        chart.ShowGradient = true;
+        chart.ShowXScale = false;
+        chart.ShowYScale = false;
+        chart.LineWidth = 1;
+        chart.CloseMarkerWidth = 1;
+        chart.Padding = 1;
+        chart.MarginTop = 10;
+        chart.MarginBottom = 10;
         chartBin.SetChild(chart);
 
         Ticker = ticker;

--- a/Stocks/Ui/Sidebar/SplitView.cs
+++ b/Stocks/Ui/Sidebar/SplitView.cs
@@ -41,13 +41,13 @@ public partial class SplitView
         details = TickerDetails.NewWithModel(model);
         detailsContainer.SetChild(details);
 
-        sidebar = new Sidebar(model);
+        sidebar = Sidebar.NewWithModel(model);
         sidebarContainer.SetChild(sidebar);
         sidebar.OnTickerActivated += OnSidebarTickerActivated;
 
-        sidebarHeader.PackStart(new AddButton(model));
+        sidebarHeader.PackStart(AddButton.NewWithModel(model));
         sidebarHeader.ShowTitle = true;
-        sidebarHeader.SetTitleWidget(new WatchlistButton(model.Watchlists));
+        sidebarHeader.SetTitleWidget(WatchlistButton.NewWithModel(model.Watchlists));
         SetupResponsiveCollapse(window);
 
         splitView.OnNotify += (_, args) =>
@@ -152,10 +152,7 @@ public partial class SplitView
 
     private void SetupResponsiveCollapse(Adw.ApplicationWindow window)
     {
-        var collapseBreakpoint = new Adw.Breakpoint
-        {
-            Condition = Adw.BreakpointCondition.Parse("max-width: 600px")
-        };
+        var collapseBreakpoint = Adw.Breakpoint.New(Adw.BreakpointCondition.Parse("max-width: 600px"));
 
         collapseBreakpoint.AddSetter(
             splitView,

--- a/Stocks/Ui/TickerContextMenu.cs
+++ b/Stocks/Ui/TickerContextMenu.cs
@@ -13,11 +13,11 @@ internal static class TickerContextMenu
         rightClick.SetButton(3);
         rightClick.OnPressed += (_, args) =>
         {
-            var remove = new Gio.MenuItem();
+            var remove = Gio.MenuItem.New(null, null);
             remove.SetLabel(Stocks.Translations._("Remove"));
             remove.SetActionAndTargetValue("app.remove", GLib.Variant.NewString(ticker.Symbol));
 
-            var refresh = new Gio.MenuItem();
+            var refresh = Gio.MenuItem.New(null, null);
             refresh.SetLabel(Stocks.Translations._("Refresh"));
             refresh.SetActionAndTargetValue("app.refreshticker", GLib.Variant.NewString(ticker.Symbol));
 

--- a/Stocks/Ui/Watchlists/WatchlistButton.cs
+++ b/Stocks/Ui/Watchlists/WatchlistButton.cs
@@ -6,14 +6,22 @@ using static Stocks.Translations;
 
 namespace Stocks.UI;
 
-public class WatchlistButton : Gtk.MenuButton
+[GObject.Subclass<Gtk.MenuButton>(qualifiedName: nameof(WatchlistButton))]
+public partial class WatchlistButton
 {
     private const string ActionGroupName = "watchlist-selector";
 
-    private readonly WatchlistModel model;
-    private readonly Gtk.Label activeWatchlistName;
+    private WatchlistModel model = null!;
+    private Gtk.Label activeWatchlistName = null!;
 
-    public WatchlistButton(WatchlistModel model)
+    public static WatchlistButton NewWithModel(WatchlistModel model)
+    {
+        var button = NewWithProperties([]);
+        button.SetModel(model);
+        return button;
+    }
+
+    private void SetModel(WatchlistModel model)
     {
         this.model = model;
 
@@ -73,7 +81,7 @@ public class WatchlistButton : Gtk.MenuButton
 
         if (GetPopoverMenuContentBox(popover) is Gtk.Box contentBox)
         {
-            var radiobuttons = new WatchlistRadioButtons(model, watchlistId =>
+            var radiobuttons = WatchlistRadioButtons.NewWithModel(model, watchlistId =>
             {
                 model.SetActiveWatchlist(watchlistId);
                 Active = false;

--- a/Stocks/Ui/Watchlists/WatchlistRadioButtons.cs
+++ b/Stocks/Ui/Watchlists/WatchlistRadioButtons.cs
@@ -5,11 +5,19 @@ using Stocks.Model;
 
 namespace Stocks.UI;
 
-internal sealed class WatchlistRadioButtons : Gtk.Box
+[GObject.Subclass<Gtk.Box>(qualifiedName: nameof(WatchlistRadioButtons))]
+internal sealed partial class WatchlistRadioButtons
 {
     private const int MaxShortcutHints = 9;
 
-    public WatchlistRadioButtons(WatchlistModel model, Action<string> onSelection)
+    public static WatchlistRadioButtons NewWithModel(WatchlistModel model, Action<string> onSelection)
+    {
+        var buttons = NewWithProperties([]);
+        buttons.SetModel(model, onSelection);
+        return buttons;
+    }
+
+    private void SetModel(WatchlistModel model, Action<string> onSelection)
     {
         SetOrientation(Gtk.Orientation.Vertical);
 

--- a/build-aux/nuget-sources.json
+++ b/build-aux/nuget-sources.json
@@ -1,191 +1,184 @@
 [
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.adw-1.0.7.0.nupkg",
-    "sha512": "1298f7513ed9fe550b3dae1f381a50c53d37cfb1fca0cb38ebcefeb5c08c8c86a3148259c84b86d8000e03898fe31521868bf413a2874033622279abf487cb30",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.adw-1/0.7.0/gircore.adw-1.0.7.0.nupkg",
+    "dest-filename": "gircore.adw-1.0.8.0.nupkg",
+    "sha512": "0a1448d9fc2f4b17305e629fb1cc7f98886b74fee48c4bda3bf7dae2c7d58b1c11a88c780abe032f8ef0788699e49f4e06472e2ae586debb9881fa9f174eed6e",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.adw-1/0.8.0/gircore.adw-1.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.cairo-1.0.0.7.0.nupkg",
-    "sha512": "b89d4874afc2a2e811df1b228b6d32c854a0d7bed6019bd3a13054e0adb3e7ea1c935bc85222c786d328712146271091ed0ecb7ad95920af165f1d96782a7b55",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.cairo-1.0/0.7.0/gircore.cairo-1.0.0.7.0.nupkg",
+    "dest-filename": "gircore.cairo-1.0.0.8.0.nupkg",
+    "sha512": "e545c1ac5c043315518f4b91e936bc8b47708d0107e2ca9e0dc6eb645fa0e104ba68bf75f12d08559815621ce026b0523d98630e144533aec888e6d80f8aae3b",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.cairo-1.0/0.8.0/gircore.cairo-1.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.freetype2-2.0.0.7.0.nupkg",
-    "sha512": "6bad6b5d64cb49f508b5cb46d21ef7288ae4bd475cddb526f76ea676ef6ee0f90355fce3e8a3cb23c9995bf981bdf8c20ea40643041d4f1af7e9926773f222a9",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.freetype2-2.0/0.7.0/gircore.freetype2-2.0.0.7.0.nupkg",
+    "dest-filename": "gircore.freetype2-2.0.0.8.0.nupkg",
+    "sha512": "058cda0af516e1add8fbb654709abe398e86c83572359e2ba8f64ad3d120206bcaf5ed34b66e524681a1bc1c0f43bbf699d6fbf95f0d3416c42ded129a954d8a",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.freetype2-2.0/0.8.0/gircore.freetype2-2.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.gdk-4.0.0.7.0.nupkg",
-    "sha512": "cbfd745df584891e1f21a0add96c62c01afbfd856add365982efd6064396b174090f8fc6ad933731995aa7bc02336b8b0909faec5f083cd31e7c2d82238133da",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gdk-4.0/0.7.0/gircore.gdk-4.0.0.7.0.nupkg",
+    "dest-filename": "gircore.gdk-4.0.0.8.0.nupkg",
+    "sha512": "2f6b846214d89106cb44a89cc5ef91bbdb8b14d95094a392c23823d950ce9ee6b5a3b2e226ec070c5344a2f3f7e539598dab01f72a99115b89b37b0f07cf3d7d",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gdk-4.0/0.8.0/gircore.gdk-4.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.gdkpixbuf-2.0.0.7.0.nupkg",
-    "sha512": "c5943548fe682d68c16faf078404a288dc88112e6eb8e207f07188801a5933dddcb5923fe5e15dba0017966bb060aace4057b47a37638adf62751bba90e60dae",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gdkpixbuf-2.0/0.7.0/gircore.gdkpixbuf-2.0.0.7.0.nupkg",
+    "dest-filename": "gircore.gdkpixbuf-2.0.0.8.0.nupkg",
+    "sha512": "aea41b0b01800c147d3c5f0b5e774df4d41950fbb19ace620c8a0e0b4599107199b3bfaf9e953ff44aaf960fef7e7b7b14a3081fa1fb5c33f44fa17093d90d80",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gdkpixbuf-2.0/0.8.0/gircore.gdkpixbuf-2.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.gio-2.0.0.7.0.nupkg",
-    "sha512": "1b2e41c18e9a5a2f09adc3da96d61d9e5fe3b87c5c952b1c1eb44c16f9493f0fc2c8fd73338acd92eb5630f93a84e0badb48abe79bb0ae1765254e2cadad2dbc",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gio-2.0/0.7.0/gircore.gio-2.0.0.7.0.nupkg",
+    "dest-filename": "gircore.gio-2.0.0.8.0.nupkg",
+    "sha512": "055c022ea323a6ca8d94be34250071c8662d8e61e93c289deea8cf29728318df6c1a925e77d4f24f4c802a0525ebee9b1e7e403720e39ae20bb5ce29f2ae73bb",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gio-2.0/0.8.0/gircore.gio-2.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.glib-2.0.0.7.0.nupkg",
-    "sha512": "e665eae755d5c231e2da079996008a5e31f85b41e15630b1b01b6e5eb7c7b0bfa7c0a235c22636449dc90700887145dee70103ac5de9dcf81acdf13629935a18",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.glib-2.0/0.7.0/gircore.glib-2.0.0.7.0.nupkg",
+    "dest-filename": "gircore.glib-2.0.0.8.0.nupkg",
+    "sha512": "dab3a451e9c8934201323bddd3fc8e4297a8955541ad9bf447f0254c02038306fb17a99d824d31cac33c2500ceee7784d945054df530859a4232fc9a5252c2ea",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.glib-2.0/0.8.0/gircore.glib-2.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.gobject-2.0.0.7.0.nupkg",
-    "sha512": "08997d4dbd05bce775a718f3c1785d7f90ff7896a8d1ce63b1d64bab9e1930621f8e818c04bb4e81e3f54bee61489de88e229aa03a9aa87ba7441e2eb978c0ef",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gobject-2.0/0.7.0/gircore.gobject-2.0.0.7.0.nupkg",
+    "dest-filename": "gircore.gobject-2.0.0.8.0.nupkg",
+    "sha512": "c6fa442b4ca5eceb8e0d5e34b5969a17e1a1f058a37cd229d6e4771aad72ca508e5111bdedf771d6c3f172af4ef437b48106ab7dd06ffe18af871509bba3380f",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gobject-2.0/0.8.0/gircore.gobject-2.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.gobject-2.0.integration.0.7.0.nupkg",
-    "sha512": "587c538b3b0a03415b3bd6a2687208550cfd653c12c32ed3a7d621ddd7d83642da8e02279f15002e9b52aeeef2b64f55c95cbc9eaecc03e5dd5b9804fd241ddc",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gobject-2.0.integration/0.7.0/gircore.gobject-2.0.integration.0.7.0.nupkg",
+    "dest-filename": "gircore.graphene-1.0.0.8.0.nupkg",
+    "sha512": "3d945815c4e99c6fde8731ee9475e990bf0b7ebef4d74e68c5e28267c4ed89e29640a3fef58ad40e189de78aa4a75a1f01f9243ed70ad7d730062cdf71c234cb",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.graphene-1.0/0.8.0/gircore.graphene-1.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.graphene-1.0.0.7.0.nupkg",
-    "sha512": "196aff4bfec5391b5ed7a607229d7eca3146bc06568ca5a1af73f09801e793dad3dd58756a849e3fd092c90179d4e92d50343fcce857096e64ff1d658827db63",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.graphene-1.0/0.7.0/gircore.graphene-1.0.0.7.0.nupkg",
+    "dest-filename": "gircore.gsk-4.0.0.8.0.nupkg",
+    "sha512": "1e743547450f06803c65988808f77e63a090d1e4aad440dc6a6e1fe3acdf026ce36c5ddbe0f2dd8b01177588514c0cc866b7fcc51d7f34a7e8f97ff857509b33",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gsk-4.0/0.8.0/gircore.gsk-4.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.gsk-4.0.0.7.0.nupkg",
-    "sha512": "7ce96ca9352be77d822a1b85ca5fdf799be3f00a79b4d14cf9950157f033f153a7d0a1ebda09188a563e4a1e4a3609363e9ce12efaab4df63d61929d8984d660",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gsk-4.0/0.7.0/gircore.gsk-4.0.0.7.0.nupkg",
+    "dest-filename": "gircore.gtk-4.0.0.8.0.nupkg",
+    "sha512": "fec0e65cf8c9e3799a9dcd4fe493f733a619cac77d5886af4436003802a5aad56808a88d90856db61604306f0b4dbcf674a9fab5ad6ff016ee2cd826a7886ca3",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gtk-4.0/0.8.0/gircore.gtk-4.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.gtk-4.0.0.7.0.nupkg",
-    "sha512": "343a7663d226eb6bbb7f6374c3751e710d2767c750027e97ee584399f99cdaecbf52de66b8589eec7d5a594f55f0e688a2b9ecfcc94cf96d6a174712e1abe375",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.gtk-4.0/0.7.0/gircore.gtk-4.0.0.7.0.nupkg",
+    "dest-filename": "gircore.harfbuzz-0.0.0.8.0.nupkg",
+    "sha512": "d51a88c4f9825285ad481ac9dab78574d00cf7e5f54cfd6d15cb8b1ccdd5d82857fc6de25e19c9906602ef3a2bfb32093fc2575e00eb7f075892033303c9852c",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.harfbuzz-0.0/0.8.0/gircore.harfbuzz-0.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.harfbuzz-0.0.0.7.0.nupkg",
-    "sha512": "7efac88a5b0d5c76acea25a4afb1f0230c0fe67dd32e1e950b66179aa3d7dfa7adb40184f1dd69877f5ff83b412ed83bbe88c4c18b10e511d310eeaf98afb631",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.harfbuzz-0.0/0.7.0/gircore.harfbuzz-0.0.0.7.0.nupkg",
+    "dest-filename": "gircore.pango-1.0.0.8.0.nupkg",
+    "sha512": "a0e6d3b908b0129c2ba896384ff4dae6f29e8a615d84595d8265d4b3242ac2d04a59b9df0a585e83f345d2b35212322406c5386954950a5a3bc4f08a2b8944ed",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.pango-1.0/0.8.0/gircore.pango-1.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.pango-1.0.0.7.0.nupkg",
-    "sha512": "5138ae3ee42e77788059d9ac40c918ddadf0c4aca5053264a4ea4b9e9d8c212884fe73f4a21ef27c0c9cff0000d682da91d32c383222fa36a49c045e01f99b80",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.pango-1.0/0.7.0/gircore.pango-1.0.0.7.0.nupkg",
+    "dest-filename": "gircore.pangocairo-1.0.0.8.0.nupkg",
+    "sha512": "5ac497f1eacfbf83fd848a1378e867bf5122346d26f21d5b7eb210a985cb460682f30305542138d31fedda8641c822fbfdf98fe017eceadef346147d11c64aa1",
+    "url": "https://api.nuget.org/v3-flatcontainer/gircore.pangocairo-1.0/0.8.0/gircore.pangocairo-1.0.0.8.0.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "gircore.pangocairo-1.0.0.7.0.nupkg",
-    "sha512": "bf78dd38244bf90e54b8c40c76426b7cae0c3116330423d9f2cf528dafc22f285fc2f3f5203b5feb8a3234e612484f6502841ceb28d5a3950db3d0cef22e33dd",
-    "url": "https://api.nuget.org/v3-flatcontainer/gircore.pangocairo-1.0/0.7.0/gircore.pangocairo-1.0.0.7.0.nupkg",
+    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm.10.0.9.nupkg",
+    "sha512": "23a432f5acbd173173fa23e9a14f1e73848487fa9406c8154279176fb6303cd60a2e9b1fef7c28c7f1145cc0b68c2c2a3720b056c9bd1d07e3b176168d54d64b",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm/10.0.9/microsoft.aspnetcore.app.runtime.linux-arm.10.0.9.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm.10.0.3.nupkg",
-    "sha512": "73bce2051c3f8b654d146d832141c3719af13fdbee584c004161f98426d0e8bd3e0518fad8ed84bda65bfa3cc1f75f88fc437b785048eda8c26c97e31932ebc4",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm/10.0.3/microsoft.aspnetcore.app.runtime.linux-arm.10.0.3.nupkg",
+    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.10.0.9.nupkg",
+    "sha512": "9098976f14639008dacc7f9cb6690ce16cac5e0a4c47df4fb3684dda823c58e27d92403bd3404b98d4b698094da0056b44614e7e092b43b9bf5de0a3dd7c787b",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/10.0.9/microsoft.aspnetcore.app.runtime.linux-arm64.10.0.9.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.10.0.3.nupkg",
-    "sha512": "00bbe88f652bf7682e88780ebab689f0d3a4c48001a33f0f3c7482a4830cb3163c26aa385c26b6a8ee4035db4a82cc01712fb09b2356535d505742a65c85e4cf",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/10.0.3/microsoft.aspnetcore.app.runtime.linux-arm64.10.0.3.nupkg",
+    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.10.0.9.nupkg",
+    "sha512": "a3b499e203e5b74a3e0384673510a358cd73a271f0e5f243afdc074f4a87c940fee7abe4ced061f561b7f92bf75dec6babb97336ab8d710bad4202023ccf19ed",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/10.0.9/microsoft.aspnetcore.app.runtime.linux-x64.10.0.9.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.10.0.3.nupkg",
-    "sha512": "5d4025c53fa23aff698734f8b0ac70de8c650f25864a1c3f33f7060d6885a7b4bbc4f906bd417c921284b12604900458b2b3f8c73383f81a42a7da1d9b6c0b3b",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/10.0.3/microsoft.aspnetcore.app.runtime.linux-x64.10.0.3.nupkg",
+    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.9.0.14.nupkg",
+    "sha512": "8d877ee4a354cdda37eb2b5cd4bcf84e501e1e144d31742bddc741cd802a0b1f707ec3949ea3ccdb89f1ed736f36bc9ac328cf89c6dd3f6c2234181d425b6cec",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/9.0.14/microsoft.aspnetcore.app.runtime.linux-x64.9.0.14.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.9.0.11.nupkg",
-    "sha512": "1565381f3b055a367799c32eca9ba444d7ac6d679088b7fe2f48034bdff7b133542f121771b671871ce5bb1528e137f81352a05ff1ba2d0ededb666a8fecf3c4",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/9.0.11/microsoft.aspnetcore.app.runtime.linux-x64.9.0.11.nupkg",
+    "dest-filename": "microsoft.net.illink.tasks.9.0.14.nupkg",
+    "sha512": "082241084d38798d55b3382c960f559dbb3a652f98c532264f1c7fd21369850777294bfd2aaad3beda9792385f2c840ae1a679c8808276f661386c1b6005f4ee",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/9.0.14/microsoft.net.illink.tasks.9.0.14.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.codeanalysis.analyzers.3.3.4.nupkg",
-    "sha512": "23e462c3affa5a33480b276888da438cdfc618feeee17b0be95b08f651bf3a316e7c7ddf96f484cbf7f1361183546c195b0abfe41967a97f8b1f676685e68f7e",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/3.3.4/microsoft.codeanalysis.analyzers.3.3.4.nupkg",
+    "dest-filename": "microsoft.netcore.app.runtime.linux-arm.10.0.9.nupkg",
+    "sha512": "f3cce4e498c32423f2a122de944dd20d4ab722f773590589c36d564319f2a48697b901c416e3036753ab7ba8bb44ca2e63d316b89084712d37964d092f5021ff",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm/10.0.9/microsoft.netcore.app.runtime.linux-arm.10.0.9.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.codeanalysis.common.4.8.0.nupkg",
-    "sha512": "477bbe806b3f45a9221aa9c17fcd27883239ea909a37583eda7eba4262aa8fa7c0bfac70f6e112d81b70b4a3a442c893103a8f9ba564d0ec2b82c3f54bead26c",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/4.8.0/microsoft.codeanalysis.common.4.8.0.nupkg",
+    "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.10.0.9.nupkg",
+    "sha512": "28a1da6960dea1ecd7b23d4178bc3133af4664a13a685c2ff3537deba493886d918e408a6f510c7af524efb9348a7ae0b540c4598646744899c9e4bb98aebc4e",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/10.0.9/microsoft.netcore.app.runtime.linux-arm64.10.0.9.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.codeanalysis.csharp.4.8.0.nupkg",
-    "sha512": "d475570908796f4c3f284eea9e2d93d64d9d2bfe7e3fdb97c0e1eef8d0d4c17e99a65a4d1fde054944010bfc30ce3169c5f99d6217a7d4bbc6934878d1aff468",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp/4.8.0/microsoft.codeanalysis.csharp.4.8.0.nupkg",
+    "dest-filename": "microsoft.netcore.app.runtime.linux-x64.10.0.9.nupkg",
+    "sha512": "9a9e4b353c95fbfe8784e17f4e92d26fcd064f54174a34dc246a298dd0e7a551c4c20e98d63acda4ee2a975a964c8e4676a6a31e9147d4990a36b86cadfe5578",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/10.0.9/microsoft.netcore.app.runtime.linux-x64.10.0.9.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.net.illink.tasks.9.0.11.nupkg",
-    "sha512": "6a035c092a7a2a776d76300acc2eee0646512d0b958cf28ba1af25827584eb540b9ed84e0ed20ddf29722291bf0ecfa5520dfb3417085c2ea041dbbb13afd500",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/9.0.11/microsoft.net.illink.tasks.9.0.11.nupkg",
+    "dest-filename": "microsoft.netcore.app.runtime.linux-x64.9.0.14.nupkg",
+    "sha512": "7fb37fa3a3fdaf12eb7ca272cb2ee9a7fef2b697be08d6bd2ddc963e36014938958bd6c83ead725cae8c3383dec0290bb284b48ce3845a67d81eb61be45c3b54",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/9.0.14/microsoft.netcore.app.runtime.linux-x64.9.0.14.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.netcore.app.runtime.linux-arm.10.0.3.nupkg",
-    "sha512": "9a69ca99f070a74707bb765544c2f3b539e7d838903f140c3701d6afb0a3e3628df6dfa7214fc75569c375990a337250f38d1b66d8c44a487de4c62ec29e6774",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm/10.0.3/microsoft.netcore.app.runtime.linux-arm.10.0.3.nupkg",
+    "dest-filename": "microsoft.netcore.app.runtime.nativeaot.linux-arm.10.0.9.nupkg",
+    "sha512": "4101ff757e4b626adb2dc2f29c0bc2d07eccbec5804756b2e728ed008e4cfcf50fb0f893c82eb423fb5509dc906178cf2a033814959646c76f828d60a7f90163",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.nativeaot.linux-arm/10.0.9/microsoft.netcore.app.runtime.nativeaot.linux-arm.10.0.9.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.10.0.3.nupkg",
-    "sha512": "de3a9896270df83170ed8a401dadb5a206dd0b381e29b84934e7a06611707cc841f9c855a3df840d804f90c8dbd1d4efa5a362cc13347efc2760e9be2cad89d7",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/10.0.3/microsoft.netcore.app.runtime.linux-arm64.10.0.3.nupkg",
+    "dest-filename": "microsoft.netcore.app.runtime.nativeaot.linux-arm64.10.0.9.nupkg",
+    "sha512": "f9e8f1da262dd059e08ca40c4a4a30c00cae3b9176b9c8a6f952fbe7fa07bae5364385d90d6a3206fc79eba5d76dcb5417be9e3450165aef0279f605c3e2d728",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.nativeaot.linux-arm64/10.0.9/microsoft.netcore.app.runtime.nativeaot.linux-arm64.10.0.9.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "microsoft.netcore.app.runtime.linux-x64.10.0.3.nupkg",
-    "sha512": "ff9b987903d5f2cb5fd61c4d5412853efaa29470c3193d308cd35afa001baf68513fee0bb8dc875677ac3ebc1625e4a39714f94e7ed4e512e9961eb03ae292ad",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/10.0.3/microsoft.netcore.app.runtime.linux-x64.10.0.3.nupkg",
-    "type": "file"
-  },
-  {
-    "dest": "nuget-sources",
-    "dest-filename": "microsoft.netcore.app.runtime.linux-x64.9.0.11.nupkg",
-    "sha512": "645d28c1fea64dcde4c222d15e2b9bfd69a63f0e4b468f099e1b0c8520fcdf88a644d4873c59bbbd8e6aab3dcbd3d4b6fe5a0ef49836a809952cd4d03bc8d08b",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/9.0.11/microsoft.netcore.app.runtime.linux-x64.9.0.11.nupkg",
+    "dest-filename": "microsoft.netcore.app.runtime.nativeaot.linux-x64.10.0.9.nupkg",
+    "sha512": "87c88980634b595ca995d54f6ba20fc1e2af768af27a1af02635b422ed8e8aa9b2494b94aa7e3f9b4fe80c9143b82db1f8d9307ce95550402b86e5366daa0186",
+    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.nativeaot.linux-x64/10.0.9/microsoft.netcore.app.runtime.nativeaot.linux-x64.10.0.9.nupkg",
     "type": "file"
   },
   {
@@ -197,23 +190,23 @@
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "system.collections.immutable.7.0.0.nupkg",
-    "sha512": "f084afc9395d74b4f252c47b7d0e378e676d6b8b6033a68636b648b58805e3772dd22ff1ded05d3c8c8553d2e7685b29b753fe1cbb5a333f018abe6422a3ebfa",
-    "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/7.0.0/system.collections.immutable.7.0.0.nupkg",
+    "dest-filename": "runtime.linux-arm.microsoft.dotnet.ilcompiler.10.0.9.nupkg",
+    "sha512": "b4e0c65b193b3b8674a903feea3b79840ac3da2779f5afa43d1dfcedc036603ee2082a4e7dd8894558d906547f19c037525ae94fee5cd69814ca757277261519",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.linux-arm.microsoft.dotnet.ilcompiler/10.0.9/runtime.linux-arm.microsoft.dotnet.ilcompiler.10.0.9.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "system.reflection.metadata.7.0.0.nupkg",
-    "sha512": "2d93c8ba1a78ceb90d25b7a3b82ae7c7f2452ad29f49ee8e1c60b2bcda19f8f6edf68689d42a586aef5faf9f1049fe5e8095ec9a4ab48a2cd2a950a8b7ec2c85",
-    "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.metadata/7.0.0/system.reflection.metadata.7.0.0.nupkg",
+    "dest-filename": "runtime.linux-arm64.microsoft.dotnet.ilcompiler.10.0.9.nupkg",
+    "sha512": "dbd32230e1b49a23c5c846d09bd10778e59a9800ee39e32814422d5fec53e39c69998fc0d4f88ee8dc03a8fa1f98cebc0b4d804fce5a7daecae95d525366e007",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.linux-arm64.microsoft.dotnet.ilcompiler/10.0.9/runtime.linux-arm64.microsoft.dotnet.ilcompiler.10.0.9.nupkg",
     "type": "file"
   },
   {
     "dest": "nuget-sources",
-    "dest-filename": "system.runtime.compilerservices.unsafe.6.0.0.nupkg",
-    "sha512": "d4057301be4ec4936f24b9ce003b5ec4d99681ab6d9b65d5393dd38d04cdec37784aaa12c1a8b50ac3767ed878dae425749490773fec01e734f93cf1045822b3",
-    "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/6.0.0/system.runtime.compilerservices.unsafe.6.0.0.nupkg",
+    "dest-filename": "runtime.linux-x64.microsoft.dotnet.ilcompiler.10.0.9.nupkg",
+    "sha512": "3f39b86e5ebab7654925a5829c09ceb95339a4ed9f628e713482a25bf5c06da475894d9563dd8b6b1990cfd710bc98b9a9b26a964956a55b24213899f6f3dc9f",
+    "url": "https://api.nuget.org/v3-flatcontainer/runtime.linux-x64.microsoft.dotnet.ilcompiler/10.0.9/runtime.linux-x64.microsoft.dotnet.ilcompiler.10.0.9.nupkg",
     "type": "file"
   }
 ]

--- a/data/ui/BrowseModeSwitcher.blp
+++ b/data/ui/BrowseModeSwitcher.blp
@@ -33,6 +33,9 @@ template $BrowseModeSwitcher : Gtk.Box {
                     styles [ "mode-icon" ]
                     icon-name: "view-list-symbolic";
                     halign: center;
+                    accessibility {
+                      label: _("List view");
+                    }
                 }
 
                 Label {
@@ -61,6 +64,9 @@ template $BrowseModeSwitcher : Gtk.Box {
                     styles [ "mode-icon" ]
                     icon-name: "view-grid-symbolic";
                     halign: center;
+                    accessibility {
+                      label: _("Grid view");
+                    }
                 }
 
                 Label {

--- a/data/ui/EmptyView.blp
+++ b/data/ui/EmptyView.blp
@@ -47,7 +47,7 @@ template $EmptyView : Gtk.Box {
 					accessibility {
 					  label: _("Add symbol");
 					}
-					css-classes: ["suggested-action", "pill"];
+					styles ["suggested-action", "pill"]
 
 					child: Adw.ButtonContent {
 						icon-name: "list-add-symbolic";

--- a/data/ui/EmptyView.blp
+++ b/data/ui/EmptyView.blp
@@ -38,9 +38,7 @@ template $EmptyView : Gtk.Box {
 			valign: center;
 			width-request: 350;
 
-			child: Box {
-				orientation: vertical;
-				spacing: 12;
+			child: Adw.Bin {
 				halign: center;
 
 				Button addSymbolButton {

--- a/data/ui/SidebarItem.blp
+++ b/data/ui/SidebarItem.blp
@@ -13,18 +13,18 @@ template $SidebarItem : Gtk.Grid {
     row-spacing: 4;
     hexpand: true;
 
-    Label symbol { 
+    Gtk.Label symbol {
         layout { column: 0; row: 0; }
-        css-classes: ["title-4"];
+        styles ["title-4"]
         halign: fill;
         hexpand: true;
         ellipsize: end;
         xalign: 0.0;
     }
 
-    Label name { 
+    Gtk.Label name {
         layout { column: 0; row: 1; }
-        css-classes: ["caption", "subtitle"];
+        styles ["caption", "subtitle"]
         halign: fill;
         hexpand: true;
         ellipsize: end;
@@ -40,17 +40,17 @@ template $SidebarItem : Gtk.Grid {
         halign: center;
     }
 
-    Label value { 
+    Gtk.Label value {
         layout { column: 2; row: 0; }
-        css-classes: ["title-4"];
+        styles ["title-4"]
         halign: end;
-        xalign: 1;
+        xalign: 1.0;
     }
 
-    Label change { 
+    Gtk.Label change {
         layout { column: 2; row: 1; }
-        css-classes: ["caption-heading"];
+        styles ["caption-heading"]
         halign: end;
-        xalign: 1;
-    }  
+        xalign: 1.0;
+    }
 }

--- a/data/ui/TickerDetails.blp
+++ b/data/ui/TickerDetails.blp
@@ -233,7 +233,7 @@ template $TickerDetails : Gtk.Box {
 
                     Label open {
                         halign: start;
-                        label: "-";
+                        label: _("-");
                         layout { column: 0; row: 1; }
                         styles [ "secondary-value" ]
                     }
@@ -247,7 +247,7 @@ template $TickerDetails : Gtk.Box {
 
                     Label high {
                         halign: start;
-                        label: "-";
+                        label: _("-");
                         layout { column: 0; row: 3; }
                         styles [ "secondary-value" ]
                     }
@@ -261,7 +261,7 @@ template $TickerDetails : Gtk.Box {
 
                     Label low {
                         halign: start;
-                        label: "-";
+                        label: _("-");
                         layout { column: 1; row: 1; }
                         styles [ "secondary-value" ]
                     }
@@ -275,7 +275,7 @@ template $TickerDetails : Gtk.Box {
 
                     Label marketStatus {
                         halign: start;
-                        label: "-";
+                        label: _("-");
                         layout { column: 1; row: 3; }
                         styles [ "secondary-value" ]
                     }
@@ -297,7 +297,7 @@ template $TickerDetails : Gtk.Box {
 
                     Label open2 {
                         halign: start;
-                        label: "-";
+                        label: _("-");
                         layout { column: 0; row: 1; }
                         styles [ "secondary-value" ]
                     }
@@ -311,7 +311,7 @@ template $TickerDetails : Gtk.Box {
 
                     Label high2 {
                         halign: start;
-                        label: "-";
+                        label: _("-");
                         layout { column: 1; row: 1; }
                         styles [ "secondary-value" ]
                     }
@@ -325,7 +325,7 @@ template $TickerDetails : Gtk.Box {
 
                     Label low2 {
                         halign: start;
-                        label: "-";
+                        label: _("-");
                         layout { column: 2; row: 1; }
                         styles [ "secondary-value" ]
                     }
@@ -339,7 +339,7 @@ template $TickerDetails : Gtk.Box {
 
                     Label marketStatus2 {
                         halign: start;
-                        label: "-";
+                        label: _("-");
                         layout { column: 3; row: 1; }
                         styles [ "secondary-value" ]
                     }

--- a/data/ui/TickerDetails.blp
+++ b/data/ui/TickerDetails.blp
@@ -11,7 +11,8 @@ template $TickerDetails : Gtk.Box {
     margin-bottom: 20;
     orientation: vertical;
 
-    Gtk.Box noDetails {
+    //TODO: This is never visible to user. EmptyState.blp is used instead. Clean up.
+    Adw.Bin noDetails {
         visible: false;
         vexpand: true;
         hexpand: true;
@@ -30,7 +31,7 @@ template $TickerDetails : Gtk.Box {
         tightening-threshold: 700; 
         hexpand: true;
 
-        Box {
+        Adw.Bin {
             styles ["card"]
             hexpand: true;
         
@@ -94,9 +95,7 @@ template $TickerDetails : Gtk.Box {
                         valign: center;
 
                         // UI for showing the symbol or alias if available
-                        Box symbolDisplayBox {
-                            orientation: horizontal;
-                            spacing: 6;
+                        Adw.Bin symbolDisplayBox {
                             halign: start;
                             valign: center;
                             styles ["symbol-display"]

--- a/data/ui/TickerDetails.blp
+++ b/data/ui/TickerDetails.blp
@@ -31,7 +31,7 @@ template $TickerDetails : Gtk.Box {
         hexpand: true;
 
         Box {
-            css-classes: ["card"];
+            styles ["card"]
             hexpand: true;
         
             Box cardContent {                    
@@ -74,7 +74,6 @@ template $TickerDetails : Gtk.Box {
                 }
 
                 Grid wideHeader {
-                    visible: true;
                     column-homogeneous: true;
                     column-spacing: 10;
                     row-spacing: 0;
@@ -89,7 +88,7 @@ template $TickerDetails : Gtk.Box {
                         layout { column: 0; row: 1; }
                         orientation: horizontal;
                         spacing: 6;
-                        css-classes: ["symbol-row"];
+                        styles ["symbol-row"]
                         halign: fill;
                         hexpand: true;
                         valign: center;
@@ -100,7 +99,7 @@ template $TickerDetails : Gtk.Box {
                             spacing: 6;
                             halign: start;
                             valign: center;
-                            css-classes: ["symbol-display"];
+                            styles ["symbol-display"]
 
                             Label symbol {
                                 halign: start;
@@ -121,7 +120,7 @@ template $TickerDetails : Gtk.Box {
 
                             Entry aliasEntry {
                                 valign: center;
-                                css-classes: ["symbol-entry"];
+                                styles ["symbol-entry"]
                                 hexpand: true;
                                 halign: fill;
                             }
@@ -130,7 +129,7 @@ template $TickerDetails : Gtk.Box {
                                 margin-top: 6;
                                 icon-name: "object-select-symbolic";
                                 valign: center;
-                                css-classes: ["suggested-action", "circular"];
+                                styles ["suggested-action", "circular"]
                                 tooltip-text: _("Save alias for symbol");
                             }
                         }
@@ -150,7 +149,6 @@ template $TickerDetails : Gtk.Box {
                 }
 
                 Adw.ToggleGroup rangeToggles {
-                    visible: true;
                     margin-top: 20;
                     margin-bottom: 20;
                     styles [ "round" ]
@@ -284,7 +282,6 @@ template $TickerDetails : Gtk.Box {
                 }
 
                 Grid wideFooter {
-                    visible: true;
                     margin-top: 20;
                     column-homogeneous: true;
                     column-spacing: 4;
@@ -363,14 +360,14 @@ template $TickerDetails : Gtk.Box {
                 margin-top: 20;
                 margin-bottom: 6;
                 label: _("Updated just now.");
-                css-classes: ["caption"];
+                styles ["caption"]
                 hexpand: true;
                 halign: start;
             }
 
             Gtk.Label readMore {
                 use-markup: true;
-                css-classes: ["caption"];
+                styles ["caption"]
                 hexpand: true;
                 halign: start;
                 opacity: 0.6;

--- a/data/ui/TickerGridCard.blp
+++ b/data/ui/TickerGridCard.blp
@@ -5,7 +5,7 @@ using Gtk 4.0;
 using Adw 1;
 
 template $TickerGridCard : Gtk.Box {
-    css-classes: [ "card" ];
+    styles [ "card" ]
     orientation: vertical;
     spacing: 8;
    
@@ -23,7 +23,7 @@ template $TickerGridCard : Gtk.Box {
 
         Label displayName {
             layout { column: 0; row: 0; }
-            css-classes: ["heading"];
+            styles ["heading"]
             max-width-chars: 10;
             halign: fill;
             hexpand: true;
@@ -33,7 +33,7 @@ template $TickerGridCard : Gtk.Box {
 
         Label name {
             layout { column: 0; row: 1; column-span: 2; }
-            css-classes: [ "caption", "dim-label" ];
+            styles [ "caption", "dim-label" ]
             max-width-chars: 18;
             halign: fill;
             hexpand: true;
@@ -43,7 +43,7 @@ template $TickerGridCard : Gtk.Box {
 
         Label change {
             layout { column: 1; row: 0; }
-            css-classes: ["caption-heading"];
+            styles ["caption-heading"]
             halign: end;
             valign: start;
             xalign: 1;
@@ -58,7 +58,7 @@ template $TickerGridCard : Gtk.Box {
     }
 
     Label value {
-        css-classes: ["title-4"];
+        styles ["title-4"]
         halign: end;
         xalign: 1;
         margin-start: 8;

--- a/po/Stocks.pot
+++ b/po/Stocks.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Stocks 0.6.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-12 09:59+0300\n"
+"POT-Creation-Date: 2026-07-04 11:40+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,45 +21,46 @@ msgstr ""
 msgid "Stocks"
 msgstr ""
 
-#: data/ui/SplitView.blp:13 data/ui/GridView.blp:9
+#: data/ui/SplitView.blp:20 data/ui/GridView.blp:17
 msgid "Symbols"
 msgstr ""
 
-#: data/ui/SplitView.blp:31 data/ui/GridView.blp:34
+#: data/ui/SplitView.blp:38 data/ui/GridView.blp:42
 msgid "Details"
 msgstr ""
 
-#: data/ui/SplitView.blp:41 data/ui/GridView.blp:20 data/ui/GridView.blp:44
-#: data/ui/EmptyView.blp:16
+#: data/ui/SplitView.blp:48 data/ui/GridView.blp:28 data/ui/GridView.blp:52
+#: data/ui/EmptyView.blp:24
 msgid "Main Menu"
 msgstr ""
 
-#: data/ui/SplitView.blp:52 data/ui/GridView.blp:55
+#: data/ui/SplitView.blp:59 data/ui/GridView.blp:63
 msgid "Refresh failed - Data can be stale"
 msgstr ""
 
-#: data/ui/SplitView.blp:72 data/ui/GridView.blp:75 data/ui/EmptyView.blp:58
+#: data/ui/SplitView.blp:80 data/ui/GridView.blp:84 data/ui/EmptyView.blp:68
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: data/ui/SplitView.blp:73 data/ui/GridView.blp:76 data/ui/EmptyView.blp:59
+#: data/ui/SplitView.blp:81 data/ui/GridView.blp:85 data/ui/EmptyView.blp:69
 msgid "About Stocks"
 msgstr ""
 
-#: data/ui/SplitView.blp:77 data/ui/GridView.blp:80 data/ui/EmptyView.blp:63
+#: data/ui/SplitView.blp:85 data/ui/GridView.blp:89 data/ui/EmptyView.blp:73
 #: data/ui/ShortcutsDialog.blp:20
 msgid "Quit"
 msgstr ""
 
-#: data/ui/EmptyView.blp:25
+#: data/ui/EmptyView.blp:33
 msgid "No symbols"
 msgstr ""
 
-#: data/ui/EmptyView.blp:26
+#: data/ui/EmptyView.blp:34
 msgid "Add symbol to your watchlist."
 msgstr ""
 
-#: data/ui/EmptyView.blp:43 Stocks/Ui/AddTicker/AddButton.cs:17
+#: data/ui/EmptyView.blp:46 data/ui/EmptyView.blp:52
+#: Stocks/Ui/AddTicker/AddButton.cs:26
 msgid "Add symbol"
 msgstr ""
 
@@ -131,112 +132,119 @@ msgstr ""
 msgid "Add tickers to your watchlist."
 msgstr ""
 
-#: data/ui/TickerDetails.blp:134
+#: data/ui/TickerDetails.blp:133
 msgid "Save alias for symbol"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:162 Stocks/Model/TickerRange.cs:46
+#: data/ui/TickerDetails.blp:160 Stocks/Model/TickerRange.cs:48
 msgid "1d"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:163 Stocks/Model/TickerRange.cs:30
+#: data/ui/TickerDetails.blp:161 Stocks/Model/TickerRange.cs:32
 msgid "1 day"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:167 Stocks/Model/TickerRange.cs:47
+#: data/ui/TickerDetails.blp:165 Stocks/Model/TickerRange.cs:49
 msgid "5d"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:168 Stocks/Model/TickerRange.cs:31
+#: data/ui/TickerDetails.blp:166 Stocks/Model/TickerRange.cs:33
 msgid "5 days"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:172 Stocks/Model/TickerRange.cs:48
+#: data/ui/TickerDetails.blp:170 Stocks/Model/TickerRange.cs:50
 msgid "1m"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:173 Stocks/Model/TickerRange.cs:32
+#: data/ui/TickerDetails.blp:171 Stocks/Model/TickerRange.cs:34
 msgid "1 month"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:177 Stocks/Model/TickerRange.cs:49
+#: data/ui/TickerDetails.blp:175 Stocks/Model/TickerRange.cs:51
 msgid "3m"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:178 Stocks/Model/TickerRange.cs:33
+#: data/ui/TickerDetails.blp:176 Stocks/Model/TickerRange.cs:35
 msgid "3 months"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:182 Stocks/Model/TickerRange.cs:50
+#: data/ui/TickerDetails.blp:180 Stocks/Model/TickerRange.cs:52
 msgid "6m"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:183 Stocks/Model/TickerRange.cs:34
+#: data/ui/TickerDetails.blp:181 Stocks/Model/TickerRange.cs:36
 msgid "6 months"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:187 Stocks/Model/TickerRange.cs:56
+#: data/ui/TickerDetails.blp:185 Stocks/Model/TickerRange.cs:58
 msgid "Ytd"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:188 Stocks/Model/TickerRange.cs:40
+#: data/ui/TickerDetails.blp:186 Stocks/Model/TickerRange.cs:42
 msgid "Year to date"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:192 Stocks/Model/TickerRange.cs:51
+#: data/ui/TickerDetails.blp:190 Stocks/Model/TickerRange.cs:53
 msgid "1y"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:193 Stocks/Model/TickerRange.cs:35
+#: data/ui/TickerDetails.blp:191 Stocks/Model/TickerRange.cs:37
 msgid "1 year"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:197 Stocks/Model/TickerRange.cs:52
+#: data/ui/TickerDetails.blp:195 Stocks/Model/TickerRange.cs:54
 msgid "2y"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:198 Stocks/Model/TickerRange.cs:36
+#: data/ui/TickerDetails.blp:196 Stocks/Model/TickerRange.cs:38
 msgid "2 years"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:202 Stocks/Model/TickerRange.cs:53
+#: data/ui/TickerDetails.blp:200 Stocks/Model/TickerRange.cs:55
 msgid "5y"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:203 Stocks/Model/TickerRange.cs:37
+#: data/ui/TickerDetails.blp:201 Stocks/Model/TickerRange.cs:39
 msgid "5 years"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:207 Stocks/Model/TickerRange.cs:54
+#: data/ui/TickerDetails.blp:205 Stocks/Model/TickerRange.cs:56
 msgid "10y"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:208 Stocks/Model/TickerRange.cs:38
+#: data/ui/TickerDetails.blp:206 Stocks/Model/TickerRange.cs:40
 msgid "10 years"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:212 data/ui/TickerDetails.blp:213
-#: Stocks/Model/TickerRange.cs:39 Stocks/Model/TickerRange.cs:55
+#: data/ui/TickerDetails.blp:210 data/ui/TickerDetails.blp:211
+#: Stocks/Model/TickerRange.cs:41 Stocks/Model/TickerRange.cs:57
 msgid "All"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:231 data/ui/TickerDetails.blp:296
+#: data/ui/TickerDetails.blp:229 data/ui/TickerDetails.blp:293
 msgid "Open"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:245 data/ui/TickerDetails.blp:310
+#: data/ui/TickerDetails.blp:236 data/ui/TickerDetails.blp:250
+#: data/ui/TickerDetails.blp:264 data/ui/TickerDetails.blp:278
+#: data/ui/TickerDetails.blp:300 data/ui/TickerDetails.blp:314
+#: data/ui/TickerDetails.blp:328 data/ui/TickerDetails.blp:342
+msgid "-"
+msgstr ""
+
+#: data/ui/TickerDetails.blp:243 data/ui/TickerDetails.blp:307
 msgid "High"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:259 data/ui/TickerDetails.blp:324
+#: data/ui/TickerDetails.blp:257 data/ui/TickerDetails.blp:321
 msgid "Low"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:273 data/ui/TickerDetails.blp:338
+#: data/ui/TickerDetails.blp:271 data/ui/TickerDetails.blp:335
 msgid "Market"
 msgstr ""
 
-#: data/ui/TickerDetails.blp:365
+#: data/ui/TickerDetails.blp:362
 msgid "Updated just now."
 msgstr ""
 
@@ -248,99 +256,99 @@ msgstr ""
 msgid "Add Watchlist"
 msgstr ""
 
-#: data/ui/BrowseModeSwitcher.blp:39
+#: data/ui/BrowseModeSwitcher.blp:37 data/ui/BrowseModeSwitcher.blp:42
 msgid "List view"
 msgstr ""
 
-#: data/ui/BrowseModeSwitcher.blp:67
+#: data/ui/BrowseModeSwitcher.blp:68 data/ui/BrowseModeSwitcher.blp:73
 msgid "Grid view"
 msgstr ""
 
-#: Stocks/Ui/Sidebar/SplitView.cs:107
+#: Stocks/Ui/Sidebar/SplitView.cs:108
 #, csharp-format
 msgid "{0} removed"
 msgstr ""
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:79
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:154
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:104
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:179
 msgid "Search symbols"
 msgstr ""
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:155
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:180
 msgid "Start typing to see search results."
 msgstr ""
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:161
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:186
 msgid "No results"
 msgstr ""
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:162
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:187
 msgid "No results found for current search term."
 msgstr ""
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:182
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:215
 msgid "Add to watchlist"
 msgstr ""
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:182
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:215
 msgid "Already on watchlist"
 msgstr ""
 
-#: Stocks/Ui/Details/TickerDetails.cs:202
+#: Stocks/Ui/Details/TickerDetails.cs:209
 msgid "Chart not available"
 msgstr ""
 
-#: Stocks/Ui/Details/TickerDetails.cs:417
+#: Stocks/Ui/Details/TickerDetails.cs:423
 #, csharp-format
 msgid "Read more on <a href=\"{0}\">Yahoo Finance</a>."
 msgstr ""
 
-#: Stocks/Ui/Details/TickerDetails.cs:445
+#: Stocks/Ui/Details/TickerDetails.cs:451
 msgctxt "market-status"
 msgid "Open"
 msgstr ""
 
-#: Stocks/Ui/Details/TickerDetails.cs:446
+#: Stocks/Ui/Details/TickerDetails.cs:452
 msgid "Closed"
 msgstr ""
 
-#: Stocks/Ui/Details/TickerDetails.cs:447
+#: Stocks/Ui/Details/TickerDetails.cs:453
 msgid "Unknown"
 msgstr ""
 
-#: Stocks/Ui/Details/TickerDetails.cs:465
+#: Stocks/Ui/Details/TickerDetails.cs:471
 msgid "Updated less than minute ago."
 msgstr ""
 
-#: Stocks/Ui/Details/TickerDetails.cs:467
+#: Stocks/Ui/Details/TickerDetails.cs:473
 #, csharp-format
 msgid "Updated {0} minutes ago."
 msgstr ""
 
-#: Stocks/Ui/Details/TickerChartPopover.cs:33
-#: Stocks/Ui/Details/TickerChartPopover.cs:84
+#: Stocks/Ui/Details/TickerChartPopover.cs:40
+#: Stocks/Ui/Details/TickerChartPopover.cs:91
 msgid "Date"
 msgstr ""
 
-#: Stocks/Ui/Details/TickerChartPopover.cs:44
+#: Stocks/Ui/Details/TickerChartPopover.cs:51
 msgid "Price"
 msgstr ""
 
-#: Stocks/Ui/Details/TickerChartPopover.cs:55
+#: Stocks/Ui/Details/TickerChartPopover.cs:62
 msgid "Change"
 msgstr ""
 
-#: Stocks/Ui/Details/TickerChartPopover.cs:84
+#: Stocks/Ui/Details/TickerChartPopover.cs:91
 msgid "Time"
 msgstr ""
 
-#: Stocks/Ui/Details/TickerChartPopover.cs:97
+#: Stocks/Ui/Details/TickerChartPopover.cs:104
 msgid "Range"
 msgstr ""
 
 #: Stocks/Ui/TickerContextMenu.cs:17
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:154
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:251
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:155
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:252
 msgid "Remove"
 msgstr ""
 
@@ -348,50 +356,50 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: Stocks/Ui/Watchlists/WatchlistButton.cs:68
+#: Stocks/Ui/Watchlists/WatchlistButton.cs:77
 msgid "Manage Watchlists..."
 msgstr ""
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:118
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:119
 msgid "Watchlist name"
 msgstr ""
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:128
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:250
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:129
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:251
 msgid "Cancel"
 msgstr ""
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:153
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:154
 msgid "Rename"
 msgstr ""
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:233
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:234
 msgid "Watchlist name is required."
 msgstr ""
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:236
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:237
 msgid "Watchlist name must be unique."
 msgstr ""
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:247
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:248
 msgid "Remove Watchlist"
 msgstr ""
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:248
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:249
 #, csharp-format
 msgid "Remove '{0}'?"
 msgstr ""
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:290
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:291
 msgid "1 symbol"
 msgstr ""
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:291
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:292
 #, csharp-format
 msgid "{0} symbols"
 msgstr ""
 
-#: Stocks/Model/Watchlists/WatchlistMigrator.cs:31
+#: Stocks/Model/Watchlists/WatchlistMigrator.cs:33
 msgctxt "Name of the default watchlist"
 msgid "Watchlist"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Stocks 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-12 09:59+0300\n"
-"PO-Revision-Date: 2026-04-11 20:25+0300\n"
+"POT-Creation-Date: 2026-07-04 11:40+0300\n"
+"PO-Revision-Date: 2026-07-04 11:46+0300\n"
 "Last-Translator: Lauri Taimila <lauri.taimila@me.com>\n"
 "Language-Team: Finnish\n"
 "Language: fi\n"
@@ -22,45 +22,46 @@ msgstr ""
 msgid "Stocks"
 msgstr "Pörssi"
 
-#: data/ui/SplitView.blp:13 data/ui/GridView.blp:9
+#: data/ui/SplitView.blp:20 data/ui/GridView.blp:17
 msgid "Symbols"
 msgstr "Symbolit"
 
-#: data/ui/SplitView.blp:31 data/ui/GridView.blp:34
+#: data/ui/SplitView.blp:38 data/ui/GridView.blp:42
 msgid "Details"
 msgstr "Tiedot"
 
-#: data/ui/SplitView.blp:41 data/ui/GridView.blp:20 data/ui/GridView.blp:44
-#: data/ui/EmptyView.blp:16
+#: data/ui/SplitView.blp:48 data/ui/GridView.blp:28 data/ui/GridView.blp:52
+#: data/ui/EmptyView.blp:24
 msgid "Main Menu"
 msgstr "Päävalikko"
 
-#: data/ui/SplitView.blp:52 data/ui/GridView.blp:55
+#: data/ui/SplitView.blp:59 data/ui/GridView.blp:63
 msgid "Refresh failed - Data can be stale"
 msgstr "Päivitys epäonnistui - Mahdollisesti vanhentunutta tietoa"
 
-#: data/ui/SplitView.blp:72 data/ui/GridView.blp:75 data/ui/EmptyView.blp:58
+#: data/ui/SplitView.blp:80 data/ui/GridView.blp:84 data/ui/EmptyView.blp:68
 msgid "Keyboard Shortcuts"
 msgstr "Pikanäppäimet"
 
-#: data/ui/SplitView.blp:73 data/ui/GridView.blp:76 data/ui/EmptyView.blp:59
+#: data/ui/SplitView.blp:81 data/ui/GridView.blp:85 data/ui/EmptyView.blp:69
 msgid "About Stocks"
 msgstr "Tietoja - Pörssi"
 
-#: data/ui/SplitView.blp:77 data/ui/GridView.blp:80 data/ui/EmptyView.blp:63
+#: data/ui/SplitView.blp:85 data/ui/GridView.blp:89 data/ui/EmptyView.blp:73
 #: data/ui/ShortcutsDialog.blp:20
 msgid "Quit"
 msgstr "Lopeta"
 
-#: data/ui/EmptyView.blp:25
+#: data/ui/EmptyView.blp:33
 msgid "No symbols"
 msgstr "Ei symboleita"
 
-#: data/ui/EmptyView.blp:26
+#: data/ui/EmptyView.blp:34
 msgid "Add symbol to your watchlist."
 msgstr "Lisää seurantalistalle."
 
-#: data/ui/EmptyView.blp:43 Stocks/Ui/AddTicker/AddButton.cs:17
+#: data/ui/EmptyView.blp:46 data/ui/EmptyView.blp:52
+#: Stocks/Ui/AddTicker/AddButton.cs:26
 msgid "Add symbol"
 msgstr "Lisää symboli"
 
@@ -132,112 +133,119 @@ msgstr "Ei symboleita"
 msgid "Add tickers to your watchlist."
 msgstr "Lisää seurantalistalle."
 
-#: data/ui/TickerDetails.blp:134
+#: data/ui/TickerDetails.blp:133
 msgid "Save alias for symbol"
 msgstr "Tallenna näyttönimi"
 
-#: data/ui/TickerDetails.blp:162 Stocks/Model/TickerRange.cs:46
+#: data/ui/TickerDetails.blp:160 Stocks/Model/TickerRange.cs:48
 msgid "1d"
 msgstr "1pv"
 
-#: data/ui/TickerDetails.blp:163 Stocks/Model/TickerRange.cs:30
+#: data/ui/TickerDetails.blp:161 Stocks/Model/TickerRange.cs:32
 msgid "1 day"
 msgstr "1 päivä"
 
-#: data/ui/TickerDetails.blp:167 Stocks/Model/TickerRange.cs:47
+#: data/ui/TickerDetails.blp:165 Stocks/Model/TickerRange.cs:49
 msgid "5d"
 msgstr "5pv"
 
-#: data/ui/TickerDetails.blp:168 Stocks/Model/TickerRange.cs:31
+#: data/ui/TickerDetails.blp:166 Stocks/Model/TickerRange.cs:33
 msgid "5 days"
 msgstr "5 päivää"
 
-#: data/ui/TickerDetails.blp:172 Stocks/Model/TickerRange.cs:48
+#: data/ui/TickerDetails.blp:170 Stocks/Model/TickerRange.cs:50
 msgid "1m"
 msgstr "1kk"
 
-#: data/ui/TickerDetails.blp:173 Stocks/Model/TickerRange.cs:32
+#: data/ui/TickerDetails.blp:171 Stocks/Model/TickerRange.cs:34
 msgid "1 month"
 msgstr "1 kuukausi"
 
-#: data/ui/TickerDetails.blp:177 Stocks/Model/TickerRange.cs:49
+#: data/ui/TickerDetails.blp:175 Stocks/Model/TickerRange.cs:51
 msgid "3m"
 msgstr "3kk"
 
-#: data/ui/TickerDetails.blp:178 Stocks/Model/TickerRange.cs:33
+#: data/ui/TickerDetails.blp:176 Stocks/Model/TickerRange.cs:35
 msgid "3 months"
 msgstr "3 kuukautta"
 
-#: data/ui/TickerDetails.blp:182 Stocks/Model/TickerRange.cs:50
+#: data/ui/TickerDetails.blp:180 Stocks/Model/TickerRange.cs:52
 msgid "6m"
 msgstr "6kk"
 
-#: data/ui/TickerDetails.blp:183 Stocks/Model/TickerRange.cs:34
+#: data/ui/TickerDetails.blp:181 Stocks/Model/TickerRange.cs:36
 msgid "6 months"
 msgstr "6 kuukautta"
 
-#: data/ui/TickerDetails.blp:187 Stocks/Model/TickerRange.cs:56
+#: data/ui/TickerDetails.blp:185 Stocks/Model/TickerRange.cs:58
 msgid "Ytd"
 msgstr "ytd"
 
-#: data/ui/TickerDetails.blp:188 Stocks/Model/TickerRange.cs:40
+#: data/ui/TickerDetails.blp:186 Stocks/Model/TickerRange.cs:42
 msgid "Year to date"
 msgstr "Vuoden alusta"
 
-#: data/ui/TickerDetails.blp:192 Stocks/Model/TickerRange.cs:51
+#: data/ui/TickerDetails.blp:190 Stocks/Model/TickerRange.cs:53
 msgid "1y"
 msgstr "1v"
 
-#: data/ui/TickerDetails.blp:193 Stocks/Model/TickerRange.cs:35
+#: data/ui/TickerDetails.blp:191 Stocks/Model/TickerRange.cs:37
 msgid "1 year"
 msgstr "1 vuosi"
 
-#: data/ui/TickerDetails.blp:197 Stocks/Model/TickerRange.cs:52
+#: data/ui/TickerDetails.blp:195 Stocks/Model/TickerRange.cs:54
 msgid "2y"
 msgstr "2v"
 
-#: data/ui/TickerDetails.blp:198 Stocks/Model/TickerRange.cs:36
+#: data/ui/TickerDetails.blp:196 Stocks/Model/TickerRange.cs:38
 msgid "2 years"
 msgstr "2 vuotta"
 
-#: data/ui/TickerDetails.blp:202 Stocks/Model/TickerRange.cs:53
+#: data/ui/TickerDetails.blp:200 Stocks/Model/TickerRange.cs:55
 msgid "5y"
 msgstr "5v"
 
-#: data/ui/TickerDetails.blp:203 Stocks/Model/TickerRange.cs:37
+#: data/ui/TickerDetails.blp:201 Stocks/Model/TickerRange.cs:39
 msgid "5 years"
 msgstr "5 vuotta"
 
-#: data/ui/TickerDetails.blp:207 Stocks/Model/TickerRange.cs:54
+#: data/ui/TickerDetails.blp:205 Stocks/Model/TickerRange.cs:56
 msgid "10y"
 msgstr "10v"
 
-#: data/ui/TickerDetails.blp:208 Stocks/Model/TickerRange.cs:38
+#: data/ui/TickerDetails.blp:206 Stocks/Model/TickerRange.cs:40
 msgid "10 years"
 msgstr "10 vuotta"
 
-#: data/ui/TickerDetails.blp:212 data/ui/TickerDetails.blp:213
-#: Stocks/Model/TickerRange.cs:39 Stocks/Model/TickerRange.cs:55
+#: data/ui/TickerDetails.blp:210 data/ui/TickerDetails.blp:211
+#: Stocks/Model/TickerRange.cs:41 Stocks/Model/TickerRange.cs:57
 msgid "All"
 msgstr "kaikki"
 
-#: data/ui/TickerDetails.blp:231 data/ui/TickerDetails.blp:296
+#: data/ui/TickerDetails.blp:229 data/ui/TickerDetails.blp:293
 msgid "Open"
 msgstr "Avaus"
 
-#: data/ui/TickerDetails.blp:245 data/ui/TickerDetails.blp:310
+#: data/ui/TickerDetails.blp:236 data/ui/TickerDetails.blp:250
+#: data/ui/TickerDetails.blp:264 data/ui/TickerDetails.blp:278
+#: data/ui/TickerDetails.blp:300 data/ui/TickerDetails.blp:314
+#: data/ui/TickerDetails.blp:328 data/ui/TickerDetails.blp:342
+msgid "-"
+msgstr "-"
+
+#: data/ui/TickerDetails.blp:243 data/ui/TickerDetails.blp:307
 msgid "High"
 msgstr "Ylin"
 
-#: data/ui/TickerDetails.blp:259 data/ui/TickerDetails.blp:324
+#: data/ui/TickerDetails.blp:257 data/ui/TickerDetails.blp:321
 msgid "Low"
 msgstr "Alin"
 
-#: data/ui/TickerDetails.blp:273 data/ui/TickerDetails.blp:338
+#: data/ui/TickerDetails.blp:271 data/ui/TickerDetails.blp:335
 msgid "Market"
 msgstr "Markkina"
 
-#: data/ui/TickerDetails.blp:365
+#: data/ui/TickerDetails.blp:362
 msgid "Updated just now."
 msgstr "Päivitetty juuri nyt."
 
@@ -249,99 +257,99 @@ msgstr "Hallitse seurantalistoja"
 msgid "Add Watchlist"
 msgstr "Luo seurantalista"
 
-#: data/ui/BrowseModeSwitcher.blp:39
+#: data/ui/BrowseModeSwitcher.blp:37 data/ui/BrowseModeSwitcher.blp:42
 msgid "List view"
 msgstr "Lista"
 
-#: data/ui/BrowseModeSwitcher.blp:67
+#: data/ui/BrowseModeSwitcher.blp:68 data/ui/BrowseModeSwitcher.blp:73
 msgid "Grid view"
 msgstr "Ruudukko"
 
-#: Stocks/Ui/Sidebar/SplitView.cs:107
+#: Stocks/Ui/Sidebar/SplitView.cs:108
 #, csharp-format
 msgid "{0} removed"
 msgstr "{0} poistettu"
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:79
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:154
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:104
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:179
 msgid "Search symbols"
 msgstr "Etsi symboleita"
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:155
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:180
 msgid "Start typing to see search results."
 msgstr "Kirjoita nähdäksesi hakutuloksia"
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:161
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:186
 msgid "No results"
 msgstr "Ei tuloksia"
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:162
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:187
 msgid "No results found for current search term."
 msgstr "Ei osumia annetulle hakusanalle."
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:182
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:215
 msgid "Add to watchlist"
 msgstr "Lisää seurantalistalle"
 
-#: Stocks/Ui/AddTicker/AddTickerPopover.cs:182
+#: Stocks/Ui/AddTicker/AddTickerPopover.cs:215
 msgid "Already on watchlist"
 msgstr "Seurantalistalla"
 
-#: Stocks/Ui/Details/TickerDetails.cs:202
+#: Stocks/Ui/Details/TickerDetails.cs:209
 msgid "Chart not available"
 msgstr "Kaavio ei ole saatavilla"
 
-#: Stocks/Ui/Details/TickerDetails.cs:417
+#: Stocks/Ui/Details/TickerDetails.cs:423
 #, csharp-format
 msgid "Read more on <a href=\"{0}\">Yahoo Finance</a>."
 msgstr "Lisätietoja <a href=\"{0}\">Yahoo Finance</a> sivuilta."
 
-#: Stocks/Ui/Details/TickerDetails.cs:445
+#: Stocks/Ui/Details/TickerDetails.cs:451
 msgctxt "market-status"
 msgid "Open"
 msgstr "Auki"
 
-#: Stocks/Ui/Details/TickerDetails.cs:446
+#: Stocks/Ui/Details/TickerDetails.cs:452
 msgid "Closed"
 msgstr "Suljettu"
 
-#: Stocks/Ui/Details/TickerDetails.cs:447
+#: Stocks/Ui/Details/TickerDetails.cs:453
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#: Stocks/Ui/Details/TickerDetails.cs:465
+#: Stocks/Ui/Details/TickerDetails.cs:471
 msgid "Updated less than minute ago."
 msgstr "Päivitetty alle minuutti sitten."
 
-#: Stocks/Ui/Details/TickerDetails.cs:467
+#: Stocks/Ui/Details/TickerDetails.cs:473
 #, csharp-format
 msgid "Updated {0} minutes ago."
 msgstr "Päivitetty {0} minuuttia sitten."
 
-#: Stocks/Ui/Details/TickerChartPopover.cs:33
-#: Stocks/Ui/Details/TickerChartPopover.cs:84
+#: Stocks/Ui/Details/TickerChartPopover.cs:40
+#: Stocks/Ui/Details/TickerChartPopover.cs:91
 msgid "Date"
 msgstr "Päivä"
 
-#: Stocks/Ui/Details/TickerChartPopover.cs:44
+#: Stocks/Ui/Details/TickerChartPopover.cs:51
 msgid "Price"
 msgstr "Hinta"
 
-#: Stocks/Ui/Details/TickerChartPopover.cs:55
+#: Stocks/Ui/Details/TickerChartPopover.cs:62
 msgid "Change"
 msgstr "Muutos"
 
-#: Stocks/Ui/Details/TickerChartPopover.cs:84
+#: Stocks/Ui/Details/TickerChartPopover.cs:91
 msgid "Time"
 msgstr "Aika"
 
-#: Stocks/Ui/Details/TickerChartPopover.cs:97
+#: Stocks/Ui/Details/TickerChartPopover.cs:104
 msgid "Range"
 msgstr "Väli"
 
 #: Stocks/Ui/TickerContextMenu.cs:17
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:154
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:251
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:155
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:252
 msgid "Remove"
 msgstr "Poista"
 
@@ -349,50 +357,50 @@ msgstr "Poista"
 msgid "Refresh"
 msgstr "Päivitä"
 
-#: Stocks/Ui/Watchlists/WatchlistButton.cs:68
+#: Stocks/Ui/Watchlists/WatchlistButton.cs:77
 msgid "Manage Watchlists..."
 msgstr "Hallitse seurantalistoja..."
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:118
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:119
 msgid "Watchlist name"
 msgstr "Seurantalistan nimi"
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:128
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:250
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:129
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:251
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:153
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:154
 msgid "Rename"
 msgstr "Nimeä uudelleen"
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:233
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:234
 msgid "Watchlist name is required."
 msgstr "Seurntalistalle on annettava nimi\t"
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:236
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:237
 msgid "Watchlist name must be unique."
 msgstr "Annettu nimi on jo käytössä"
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:247
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:248
 msgid "Remove Watchlist"
 msgstr "Poista seurantalista"
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:248
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:249
 #, csharp-format
 msgid "Remove '{0}'?"
 msgstr "Poista '{0}'?"
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:290
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:291
 msgid "1 symbol"
 msgstr "1 symboli"
 
-#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:291
+#: Stocks/Ui/Watchlists/WatchlistManageDialog.cs:292
 #, csharp-format
 msgid "{0} symbols"
 msgstr "{0} symbolia"
 
-#: Stocks/Model/Watchlists/WatchlistMigrator.cs:31
+#: Stocks/Model/Watchlists/WatchlistMigrator.cs:33
 msgctxt "Name of the default watchlist"
 msgid "Watchlist"
 msgstr "Seurantalista"


### PR DESCRIPTION
Fixed all compiler warnings including all gir.core produced warnings about GObject subclass constructors.

Enabled `TreatWarningsAsErrors` for project to avoid compiler warnings cumulating in the future.