### PR TITLE
Allow Grid View to get narrow enough for phones

### DIFF
--- a/Stocks/Ui/Grid/TickerGrid.cs
+++ b/Stocks/Ui/Grid/TickerGrid.cs
@@ -9,7 +9,7 @@ namespace Stocks.UI;
 public partial class TickerGrid
 {
     private AppModel model = null!;
-    private readonly Dictionary<Symbol, Gtk.AspectFrame> cards = [];
+    private readonly Dictionary<Symbol, TickerGridCardFrame> cards = [];
 
     // Container for all on-going animations during drag operation
     private readonly Dictionary<Gtk.FlowBoxChild, (Adw.TimedAnimation Animation, Adw.CallbackAnimationTarget Target)> activeCardAnimations = [];
@@ -52,8 +52,8 @@ public partial class TickerGrid
 
         OnChildActivated += (_, args) =>
         {
-            if (args.Child?.Child is Gtk.AspectFrame card && card.Child is TickerGridCard tgc)
-                OnTickerActivated?.Invoke(tgc.Ticker);
+            if (args.Child?.Child is TickerGridCardFrame card && card.Ticker is not null)
+                OnTickerActivated?.Invoke(card.Ticker);
         };        
     }
 
@@ -77,16 +77,9 @@ public partial class TickerGrid
         Append(card);
     }
 
-    private Gtk.AspectFrame CreateCard(Ticker ticker)
+    private TickerGridCardFrame CreateCard(Ticker ticker)
     {
-        int cardSize = 180;
-
-        var aspectFrame = Gtk.AspectFrame.New(0.5f, 0.5f, 1.0f, false);
-        aspectFrame.WidthRequest = cardSize;
-        aspectFrame.HeightRequest = cardSize;
-        aspectFrame.SetChild(TickerGridCard.NewWithTicker(ticker));
-
-        return aspectFrame;
+        return TickerGridCardFrame.NewWithTicker(ticker);
     }
 
     private void RemoveTicker(Ticker ticker)
@@ -101,7 +94,7 @@ public partial class TickerGrid
         }
     }
 
-    private void SetupDragAndDrop(Gtk.AspectFrame card)
+    private void SetupDragAndDrop(TickerGridCardFrame card)
     {
         var dragSource = Gtk.DragSource.New();
         dragSource.SetActions(Gdk.DragAction.Move);
@@ -128,8 +121,8 @@ public partial class TickerGrid
                 dragSource.SetIcon(paintable, 0, 0);
             }
 
-            card.SetChild(null);
-            card.AddCssClass("drag-placeholder");
+            card.RemoveContent();
+            card.AddPlaceholderClass();
         };
 
         dragSource.OnDragEnd += (_, _) =>
@@ -138,7 +131,7 @@ public partial class TickerGrid
             CleanupDragState();
         };
         
-        card.AddController(dragSource);
+        card.AddCardController(dragSource);
 
         var dropTarget = Gtk.DropTarget.New(GObject.Type.Object, Gdk.DragAction.Move);
         dropTarget.OnDrop += (_, _) =>
@@ -175,7 +168,7 @@ public partial class TickerGrid
             return Gdk.DragAction.Move;
         };
 
-        card.AddController(dropTarget);
+        card.AddCardController(dropTarget);
     }
 
     private void UpdateUItoMatchTickerOrderInModel()
@@ -184,7 +177,7 @@ public partial class TickerGrid
         {
             var ticker = model.Tickers[i];
 
-            if (GetFloxBoxChildOf(ticker) is not Gtk.FlowBoxChild child)
+            if (GetFlowBoxChildOf(ticker) is not Gtk.FlowBoxChild child)
                 continue;
 
             if (child.GetIndex() == i)
@@ -195,7 +188,7 @@ public partial class TickerGrid
         }
     }
 
-    private Gtk.FlowBoxChild? GetFloxBoxChildOf(Ticker ticker)
+    private Gtk.FlowBoxChild? GetFlowBoxChildOf(Ticker ticker)
     {
         if (!cards.TryGetValue(ticker.Symbol, out var item))
             return null;
@@ -283,10 +276,10 @@ public partial class TickerGrid
             return;
 
         SetCardOffset(dragState.FlowBoxChild, 0, 0);
-        dragState.Card.RemoveCssClass("drag-placeholder");
+        dragState.Card.RemovePlaceholderClass();
 
-        if (dragState.Card.Child == null && dragState.CardContent != null)
-            dragState.Card.SetChild(dragState.CardContent);
+        if (!dragState.Card.HasContent && dragState.CardContent != null)
+            dragState.Card.SetContent(dragState.CardContent);
 
         dragState = null;
     }
@@ -345,12 +338,12 @@ public partial class TickerGrid
     }
 }
 
-class DragState(Gtk.FlowBoxChild fbc, Gtk.AspectFrame card)
+class DragState(Gtk.FlowBoxChild fbc, TickerGridCardFrame card)
 {
     public Gtk.FlowBoxChild FlowBoxChild { get; } = fbc;
-    public Gtk.AspectFrame Card { get; } = card;
-    public Gtk.Widget? CardContent { get; } = card.Child;
-    public Gtk.AspectFrame? DragIconCard { get; set; }
+    public TickerGridCardFrame Card { get; } = card;
+    public Gtk.Widget? CardContent { get; } = card.Content;
+    public TickerGridCardFrame? DragIconCard { get; set; }
     public Ticker? Ticker => (CardContent as TickerGridCard)?.Ticker;
 }
     

--- a/Stocks/Ui/Grid/TickerGridCardFrame.cs
+++ b/Stocks/Ui/Grid/TickerGridCardFrame.cs
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Lauri Taimila
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using Stocks.Model;
+
+namespace Stocks.UI;
+
+[GObject.Subclass<Gtk.Widget>(qualifiedName: nameof(TickerGridCardFrame))]
+public partial class TickerGridCardFrame
+{
+    // This container "frame" enforces ticker card size in the grid
+    // to be between min max values defined here.
+    private const int MinCardSize = 155;
+    private const int MaxCardSize = 180;
+
+    private Gtk.AspectFrame aspectFrame = null!;
+
+    public static TickerGridCardFrame NewWithTicker(Ticker ticker)
+    {
+        var frame = NewWithProperties([]);
+        frame.SetupWidget(ticker);
+        return frame;
+    }
+
+    private void SetupWidget(Ticker ticker)
+    {
+        LayoutManager = Gtk.CustomLayout.New(RequestMode, Measure, Allocate);
+
+        aspectFrame = Gtk.AspectFrame.New(0.5f, 0.5f, 1.0f, false);
+        aspectFrame.SetChild(TickerGridCard.NewWithTicker(ticker));
+        aspectFrame.SetParent(this);
+    }
+
+    public Ticker? Ticker => (aspectFrame.Child as TickerGridCard)?.Ticker;
+    public Gtk.Widget? Content => aspectFrame.Child;
+    public bool HasContent => aspectFrame.Child is not null;
+
+    public void SetContent(Gtk.Widget content)
+    {
+        aspectFrame.SetChild(content);
+    }
+
+    public void RemoveContent()
+    {
+        aspectFrame.SetChild(null);
+    }
+
+    public void AddPlaceholderClass()
+    {
+        aspectFrame.AddCssClass("drag-placeholder");
+    }
+
+    public void RemovePlaceholderClass()
+    {
+        aspectFrame.RemoveCssClass("drag-placeholder");
+    }
+
+    public void AddCardController(Gtk.EventController controller)
+    {
+        aspectFrame.AddController(controller);
+    }
+
+    public override void Dispose()
+    {
+        if (aspectFrame is not null && aspectFrame.Parent is not null)
+            aspectFrame.Unparent();
+
+        base.Dispose();
+    }
+
+    private static Gtk.SizeRequestMode RequestMode(Gtk.Widget widget)
+    {
+        return Gtk.SizeRequestMode.HeightForWidth;
+    }
+
+    private static void Measure(
+        Gtk.Widget widget,
+        Gtk.Orientation orientation,
+        int forSize,
+        out int minimum,
+        out int natural,
+        out int minimumBaseline,
+        out int naturalBaseline)
+    {
+        minimumBaseline = -1;
+        naturalBaseline = -1;
+
+        if (orientation == Gtk.Orientation.Horizontal || forSize < 0)
+        {
+            minimum = MinCardSize;
+            natural = MaxCardSize;
+            return;
+        }
+
+        var size = Math.Clamp(forSize, MinCardSize, MaxCardSize);
+        minimum = size;
+        natural = size;
+    }
+
+    private static void Allocate(Gtk.Widget widget, int width, int height, int baseline)
+    {
+        if (widget.GetFirstChild() is not Gtk.Widget child)
+            return;
+
+        var size = Math.Min(Math.Min(width, height), MaxCardSize);
+        child.Allocate(size, size, baseline, null!);
+    }
+}
+    

--- a/Stocks/Ui/MainWindow.cs
+++ b/Stocks/Ui/MainWindow.cs
@@ -29,6 +29,8 @@ public partial class MainWindow
 
     private void SetModel(Adw.Application application, AppModel model, Gio.Settings settings)
     {
+        WidthRequest = 355;
+
         this.model = model;
         Application = application;
 
@@ -58,7 +60,6 @@ public partial class MainWindow
         SetupPrimaryMenu();
         SetupUpdatesOnWindowResize();
         UpdateUI();
-        SetMinumumWidth(mode.Current);
     }
 
     private void SetBrowseMode(BrowseMode mode)
@@ -69,12 +70,6 @@ public partial class MainWindow
         this.mode.SetBrowseMode(mode);
         UpdateUI();
         UpdateResponsiveState();
-        SetMinumumWidth(mode);
-    }
-
-    private void SetMinumumWidth(BrowseMode mode)
-    {
-        WidthRequest = mode == BrowseMode.Grid ? 404 : 355;
     }
 
     // If there are no tickers, there is no visible change in UI, but mode still changes.


### PR DESCRIPTION
GridView used to have separate minimum width for the main window from split view. This causes issued causes with phone UI based on (ctrl+shift+m) phone previewer.

This fix allows window to get narrow enough in grid mode by resizing cards smaller when the window gets really narrow.