### PR TITLE
Decrease flatpak size

### DIFF
--- a/Stocks.csproj
+++ b/Stocks.csproj
@@ -13,7 +13,8 @@
     <Nullable>enable</Nullable>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishTrimmed>false</PublishTrimmed>
+    <PublishTrimmed>true</PublishTrimmed>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/Stocks/Model/AliasStorage.cs
+++ b/Stocks/Model/AliasStorage.cs
@@ -49,7 +49,7 @@ public class AliasStorage
         try
         {
             var json = File.ReadAllText(filePath);
-            var data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+            var data = JsonSerializer.Deserialize(json, StocksJsonContext.Default.StringDictionary);
             if (data != null)
             {
                 aliases = data
@@ -76,7 +76,9 @@ public class AliasStorage
             if (!string.IsNullOrWhiteSpace(directory))
                 Directory.CreateDirectory(directory);
 
-            var json = JsonSerializer.Serialize(aliases.ToDictionary(pair => pair.Key.Value, pair => pair.Value));
+            var json = JsonSerializer.Serialize(
+                aliases.ToDictionary(pair => pair.Key.Value, pair => pair.Value),
+                StocksJsonContext.Default.StringDictionary);
             File.WriteAllText(filePath, json);
         }
         catch

--- a/Stocks/Model/StocksJsonContext.cs
+++ b/Stocks/Model/StocksJsonContext.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Lauri Taimila
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+using System.Text.Json.Serialization;
+
+namespace Stocks.Model;
+
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(Dictionary<string, string>), TypeInfoPropertyName = "StringDictionary")]
+[JsonSerializable(typeof(WatchlistState))]
+[JsonSerializable(typeof(ChartResponse))]
+[JsonSerializable(typeof(YahooSearchResults))]
+internal partial class StocksJsonContext : JsonSerializerContext
+{
+}

--- a/Stocks/Model/TickerFetcher.cs
+++ b/Stocks/Model/TickerFetcher.cs
@@ -23,8 +23,7 @@ public class TickerFetcher
         try
         {
             var json = await client.GetStringAsync(url);
-            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            var dto = JsonSerializer.Deserialize<ChartResponse>(json, options);
+            var dto = JsonSerializer.Deserialize(json, StocksJsonContext.Default.ChartResponse);
             return dto!.Chart.Result!.First();
         }
         catch(Exception e)
@@ -42,8 +41,7 @@ public class TickerFetcher
         try
         {
             var json = await client.GetStringAsync(url);
-            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            var dto = JsonSerializer.Deserialize<YahooSearchResults>(json, options);
+            var dto = JsonSerializer.Deserialize(json, StocksJsonContext.Default.YahooSearchResults);
             return dto!.Quotes.ToList();
         }
         catch(Exception e)
@@ -97,7 +95,7 @@ public record ChartResponse(
 
 public record ChartData(
     IReadOnlyList<Result>? Result,
-    object? Error
+    JsonElement? Error
 );
 
 public record Result(

--- a/Stocks/Model/Watchlists/WatchlistStorage.cs
+++ b/Stocks/Model/Watchlists/WatchlistStorage.cs
@@ -47,7 +47,7 @@ public class WatchlistStorage
         try
         {
             var json = File.ReadAllText(filePath);
-            var loaded = JsonSerializer.Deserialize<WatchlistState>(json);
+            var loaded = JsonSerializer.Deserialize(json, StocksJsonContext.Default.WatchlistState);
             if (loaded is null)
                 return false;
 
@@ -68,7 +68,7 @@ public class WatchlistStorage
             if (!string.IsNullOrWhiteSpace(directory))
                 Directory.CreateDirectory(directory);
 
-            var json = JsonSerializer.Serialize(state);
+            var json = JsonSerializer.Serialize(state, StocksJsonContext.Default.WatchlistState);
             File.WriteAllText(filePath, json);
             return true;
         }


### PR DESCRIPTION
Implements issue #22 by enabling ` <PublishTrimmed>true</PublishTrimmed>`. To be able to do that JSON handling was updated to use source generation (compile time) rather than reflection based (runtime).

As a result package size went down from 23MB to 6MB. 🥳